### PR TITLE
Integrate game-scoped final leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,7 @@ Make sure Docker Desktop is installed and running. On older Docker versions the 
 
 **Port 3000 is already in use**
 Another app is using port 3000. Stop that app, or run `docker compose down` first to clean up any leftover containers.
+
+
+## Licence
+See the LICENSE file in the root of the Repository for the project's MIT license.

--- a/app/LICENSE
+++ b/app/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2026 Kimply Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -13,15 +13,54 @@ function generateSequence(length) {
 async function checkWinner(roundId) {
   const players = await PlayersCollection.find({ roundId }).fetchAsync();
 
-  const active = players.filter((p) => !p.eliminated);
+  const alreadyFinished = players.some((p) => p.gameFinished);
+  if (alreadyFinished) return;
 
-  const alreadyWinner = players.some((p) => p.winner);
-  if (alreadyWinner) return;
+  const active = players.filter((p) => !p.eliminated);
 
   if (active.length === 1) {
     await PlayersCollection.updateAsync(active[0]._id, {
-      $set: { winner: true },
+      $set: {
+        winner: true,
+      },
     });
+
+    await PlayersCollection.updateAsync(
+      { roundId },
+      {
+        $set: {
+          gameFinished: true,
+        },
+      },
+      { multi: true }
+    );
+  }
+
+  if (active.length === 0 && players.length > 0) {
+    const highestRound = Math.max(...players.map((p) => p.eliminatedRound ?? 0));
+
+    await PlayersCollection.updateAsync(
+      {
+        roundId,
+        eliminatedRound: highestRound,
+      },
+      {
+        $set: {
+          winner: true,
+        },
+      },
+      { multi: true }
+    );
+
+    await PlayersCollection.updateAsync(
+      { roundId },
+      {
+        $set: {
+          gameFinished: true,
+        },
+      },
+      { multi: true }
+    );
   }
 }
 
@@ -52,6 +91,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         eliminated: false,
         winner: false,
         completeRound: false,
+        gameFinished: false,
       });
     },
 

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -10,8 +10,8 @@ function generateSequence(length) {
   return Array.from({ length }, () => COLOURS[Math.floor(Math.random() * COLOURS.length)]);
 }
 
-async function checkWinner(roundId) {
-  const players = await PlayersCollection.find({ roundId }).fetchAsync();
+async function checkWinner(gameId) {
+  const players = await PlayersCollection.find({ gameId }).fetchAsync();
 
   const alreadyFinished = players.some((p) => p.gameFinished);
   if (alreadyFinished) return;
@@ -26,7 +26,7 @@ async function checkWinner(roundId) {
     });
 
     await PlayersCollection.updateAsync(
-      { roundId },
+      { gameId },
       {
         $set: {
           gameFinished: true,
@@ -41,7 +41,7 @@ async function checkWinner(roundId) {
 
     await PlayersCollection.updateAsync(
       {
-        roundId,
+        gameId,
         eliminatedRound: highestRound,
       },
       {
@@ -53,7 +53,7 @@ async function checkWinner(roundId) {
     );
 
     await PlayersCollection.updateAsync(
-      { roundId },
+      { gameId },
       {
         $set: {
           gameFinished: true,
@@ -71,7 +71,10 @@ async function advanceRoundIfReady(round) {
 
   const activePlayers = playersInRound.filter((p) => !p.eliminated);
   const allFinished = activePlayers.length > 0 && activePlayers.every((p) => p.completeRound);
-  const hasWinner = playersInRound.some((p) => p.winner);
+  const hasWinner = await PlayersCollection.findOneAsync({
+    gameId: round.gameId,
+    winner: true,
+  });
 
   if (!round.advanced && allFinished && !hasWinner) {
     await Meteor.callAsync('rounds.advance', round._id);
@@ -82,10 +85,11 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
   global._gameMethodsInitialized = true;
   Meteor.methods({
     // Generate a new round with a colour sequence
-    'rounds.generate'(length = 4) {
+    'rounds.generate'(length = 4, gameId = null) {
       const sequence = generateSequence(length);
 
       return RoundsCollection.insertAsync({
+        gameId,
         lengthOfSequence: length,
         sequence,
         createdAt: new Date(),
@@ -95,8 +99,9 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
     },
 
     // Add a player to a round
-    'players.join'(roundId, playerName) {
+    'players.join'(roundId, playerName, gameId = null) {
       return PlayersCollection.insertAsync({
+        gameId,
         roundId,
         name: playerName,
         lives: 3,
@@ -128,10 +133,11 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
           },
         });
 
-        await checkWinner(player.roundId);
+        await checkWinner(player.gameId);
 
         // add successful completion to leaderboard
         await LeaderboardCollection.insertAsync({
+          gameId: player.gameId,
           playerId,
           name: player.name,
           lives: player.lives,
@@ -152,11 +158,11 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
           },
         });
 
-        await checkWinner(player.roundId);
+        await checkWinner(player.gameId);
         
         const updatedRound = await RoundsCollection.findOneAsync(player.roundId);
         await advanceRoundIfReady(updatedRound);
-        
+
         // return failed attempt to client
         return {
           success: false,
@@ -217,6 +223,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
 
       // create next round
       const nextRoundId = await RoundsCollection.insertAsync({
+        gameId: currentRound.gameId,
         lengthOfSequence: nextLength,
         sequence: nextSequence,
         createdAt: new Date(),

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -108,6 +108,8 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         attemptedSequence: [],
         currentStreak: 0,
         longestStreak: 0,
+        totalGuesses: 0,
+        correctGuesses: 0,
         eliminatedRound: null,
         eliminated: false,
         winner: false,
@@ -129,6 +131,8 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
       if (correct) {
         const currentStreak = (player.currentStreak ?? 0) + 1;
         const longestStreak = Math.max(player.longestStreak ?? 0, currentStreak);
+        const totalGuesses = (player.totalGuesses ?? 0) + 1;
+        const correctGuesses = (player.correctGuesses ?? 0) + 1;
 
         // mark player as completed
         await PlayersCollection.updateAsync(playerId, {
@@ -136,6 +140,8 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
             attemptedSequence,
             currentStreak,
             longestStreak,
+            totalGuesses,
+            correctGuesses,
             completeRound: true,
           },
         });
@@ -156,6 +162,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         const newLives = player.lives - 1;
         const eliminated = newLives <= 0;
         const longestStreak = Math.max(player.longestStreak ?? 0, player.currentStreak ?? 0);
+        const totalGuesses = (player.totalGuesses ?? 0) + 1;
 
         await PlayersCollection.updateAsync(playerId, {
           $set: {
@@ -163,6 +170,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
             lives: newLives,
             currentStreak: 0,
             longestStreak,
+            totalGuesses,
             eliminated,
             eliminatedRound: eliminated ? round.lengthOfSequence - 3 : player.eliminatedRound,
           },

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -48,6 +48,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         name: playerName,
         lives: 3,
         attemptedSequence: [],
+        eliminatedRound: null,
         eliminated: false,
         winner: false,
         completeRound: false,
@@ -86,12 +87,14 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
       } else {
         // remove one life for wrong sequence
         const newLives = player.lives - 1;
+        const eliminated = newLives <= 0;
 
         await PlayersCollection.updateAsync(playerId, {
           $set: {
             attemptedSequence,
             lives: newLives,
-            eliminated: newLives <= 0,
+            eliminated,
+            eliminatedRound: eliminated ? round.lengthOfSequence - 3 : player.eliminatedRound,
           },
         });
 

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -64,6 +64,20 @@ async function checkWinner(roundId) {
   }
 }
 
+async function advanceRoundIfReady(round) {
+  const playersInRound = await PlayersCollection.find({
+    roundId: round._id,
+  }).fetchAsync();
+
+  const activePlayers = playersInRound.filter((p) => !p.eliminated);
+  const allFinished = activePlayers.length > 0 && activePlayers.every((p) => p.completeRound);
+  const hasWinner = playersInRound.some((p) => p.winner);
+
+  if (!round.advanced && allFinished && !hasWinner) {
+    await Meteor.callAsync('rounds.advance', round._id);
+  }
+}
+
 if (Meteor.isServer && !global._gameMethodsInitialized) {
   global._gameMethodsInitialized = true;
   Meteor.methods({
@@ -139,7 +153,10 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         });
 
         await checkWinner(player.roundId);
-
+        
+        const updatedRound = await RoundsCollection.findOneAsync(player.roundId);
+        await advanceRoundIfReady(updatedRound);
+        
         // return failed attempt to client
         return {
           success: false,

--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -106,6 +106,8 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         name: playerName,
         lives: 3,
         attemptedSequence: [],
+        currentStreak: 0,
+        longestStreak: 0,
         eliminatedRound: null,
         eliminated: false,
         winner: false,
@@ -125,10 +127,15 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
 
       // if correct update player values
       if (correct) {
+        const currentStreak = (player.currentStreak ?? 0) + 1;
+        const longestStreak = Math.max(player.longestStreak ?? 0, currentStreak);
+
         // mark player as completed
         await PlayersCollection.updateAsync(playerId, {
           $set: {
             attemptedSequence,
+            currentStreak,
+            longestStreak,
             completeRound: true,
           },
         });
@@ -148,18 +155,21 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         // remove one life for wrong sequence
         const newLives = player.lives - 1;
         const eliminated = newLives <= 0;
+        const longestStreak = Math.max(player.longestStreak ?? 0, player.currentStreak ?? 0);
 
         await PlayersCollection.updateAsync(playerId, {
           $set: {
             attemptedSequence,
             lives: newLives,
+            currentStreak: 0,
+            longestStreak,
             eliminated,
             eliminatedRound: eliminated ? round.lengthOfSequence - 3 : player.eliminatedRound,
           },
         });
 
         await checkWinner(player.gameId);
-        
+
         const updatedRound = await RoundsCollection.findOneAsync(player.roundId);
         await advanceRoundIfReady(updatedRound);
 

--- a/app/imports/api/rooms.js
+++ b/app/imports/api/rooms.js
@@ -59,6 +59,7 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
       if (!room) throw new Meteor.Error('not-found', 'Room not found');
       if (room.status !== 'lobby') throw new Meteor.Error('not-lobby', 'Game already started');
       await RoomsCollection.updateAsync({ _id: room._id }, { $set: { status: 'in_progress' } });
+      await Meteor.callAsync('rounds.generate', 4, room.pin);
     },
 
     async 'rooms.kick'(pin, playerId) {

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -10,7 +10,12 @@ const MEDAL = [
   { color: 'oklch(0.72 0.14 55)', label: '3rd' },
 ];
 
-export const EndLeaderboard = ({ gameId }) => {
+function ordinal(rank) {
+  const suffix = rank % 100 >= 11 && rank % 100 <= 13 ? 'th' : ['th', 'st', 'nd', 'rd'][rank % 10] || 'th';
+  return `${rank}${suffix}`;
+}
+
+export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
   const navigate = useNavigate();
 
   const players = useTracker(() => {
@@ -40,6 +45,11 @@ export const EndLeaderboard = ({ gameId }) => {
   const rankKey = (player) => (player.isWinner ? 'winner' : player.eliminatedRound);
   const uniqueRanks = [...new Set(sorted.map(rankKey))];
   const ranks = sorted.map((player) => uniqueRanks.indexOf(rankKey(player)));
+  const currentPlayer = sorted.find((player) => player.id === currentPlayerId);
+  const currentRank = currentPlayer ? uniqueRanks.indexOf(rankKey(currentPlayer)) + 1 : null;
+  const currentRankIsTied = currentPlayer
+    ? sorted.filter((player) => rankKey(player) === rankKey(currentPlayer)).length > 1
+    : false;
 
   // Group top-3 ranks into podium blocks, displayed as 2nd | 1st | 3rd
   const byRank = [0, 1, 2].map((rank) => sorted.filter((p) => ranks[sorted.indexOf(p)] === rank));
@@ -87,9 +97,22 @@ export const EndLeaderboard = ({ gameId }) => {
             Final Results
           </p>
           <h1 className="font-outfit text-5xl font-extrabold tracking-tight">Leaderboard</h1>
-          {winnerGroup.length > 0 && (
+          {currentRank && (
             <div
               className="mt-4 rounded-full px-4 py-2 font-outfit text-sm font-extrabold"
+              style={{
+                color: PRIMARY,
+                background: `color-mix(in oklab, ${PRIMARY} 16%, transparent)`,
+                border: `1px solid color-mix(in oklab, ${PRIMARY} 42%, transparent)`,
+                animation: 'winnerCrown 1.1s cubic-bezier(0.22,1,0.36,1) 0.2s both',
+              }}
+            >
+              {currentRankIsTied ? `You tied for ${ordinal(currentRank)}` : `You came ${ordinal(currentRank)}`}
+            </div>
+          )}
+          {winnerGroup.length > 0 && (
+            <div
+              className="mt-3 rounded-full px-4 py-2 font-outfit text-sm font-extrabold"
               style={{
                 color: BG,
                 background: `linear-gradient(135deg, ${MEDAL[0].color}, ${PRIMARY})`,

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -41,7 +41,7 @@ export const EndLeaderboard = ({ gameId }) => {
   // Group top-3 ranks into podium blocks, displayed as 2nd | 1st | 3rd
   const byRank = [0, 1, 2].map((rank) => sorted.filter((p) => ranks[sorted.indexOf(p)] === rank));
   const podiumOrder = [byRank[1], byRank[0], byRank[2]];
-  const podiumHeights = [72, 100, 56];
+  const podiumHeights = [90, 120, 72];
   const winnerGroup = byRank[0] ?? [];
   const highestEliminatedRound = Math.max(0, ...players.map((player) => player.eliminatedRound ?? 0));
 
@@ -97,7 +97,7 @@ export const EndLeaderboard = ({ gameId }) => {
         </div>
 
         {/* Podium */}
-        <div className="mb-10 flex w-full max-w-md items-end justify-center gap-3 overflow-hidden px-1">
+        <div className="w-full max-w-md flex items-end justify-center gap-3 mb-10">
           {podiumOrder.map((group, i) => {
             const medalIndex = i === 0 ? 1 : i === 1 ? 0 : 2;
             const medal = MEDAL[medalIndex];

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -234,6 +234,7 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
             const medal = MEDAL[rank];
             const rowColor = medal ? medal.color : 'oklch(0.93 0.01 270)';
             const rowDelay = 1.5 + index * 0.04;
+            const isCurrentPlayer = player.id === currentPlayerId;
 
             return (
               <div
@@ -243,12 +244,17 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
                   animation: `scoreboardRowIn 0.55s cubic-bezier(0.22,1,0.36,1) ${rowDelay}s both`,
                   background: medal
                     ? `color-mix(in oklab, ${medal.color} 12%, transparent)`
-                    : 'color-mix(in oklab, white 4%, transparent)',
+                    : isCurrentPlayer
+                      ? `color-mix(in oklab, ${PRIMARY} 14%, transparent)`
+                      : 'color-mix(in oklab, white 4%, transparent)',
                   border: `1px solid ${
-                    medal
-                      ? `color-mix(in oklab, ${medal.color} 30%, transparent)`
-                      : `color-mix(in oklab, white 8%, transparent)`
+                    isCurrentPlayer
+                      ? `color-mix(in oklab, ${PRIMARY} 48%, transparent)`
+                      : medal
+                        ? `color-mix(in oklab, ${medal.color} 30%, transparent)`
+                        : `color-mix(in oklab, white 8%, transparent)`
                   }`,
+                  boxShadow: isCurrentPlayer ? `0 0 22px color-mix(in oklab, ${PRIMARY} 18%, transparent)` : 'none',
                 }}
               >
                 <span className="w-12 shrink-0 font-outfit text-sm font-extrabold" style={{ color: rowColor }}>
@@ -266,6 +272,18 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
                       style={{ color: PRIMARY, animation: 'winnerPulse 1.5s ease-in-out infinite' }}
                     >
                       Winner
+                    </span>
+                  )}
+                  {isCurrentPlayer && (
+                    <span
+                      className="ml-2 rounded-full px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+                      style={{
+                        color: PRIMARY,
+                        background: `color-mix(in oklab, ${PRIMARY} 16%, transparent)`,
+                        border: `1px solid color-mix(in oklab, ${PRIMARY} 38%, transparent)`,
+                      }}
+                    >
+                      You
                     </span>
                   )}
                 </span>

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { PlayersCollection } from '../api/players';
 import { useNavigate } from 'react-router-dom';
 import { BG, PRIMARY, TILE, HAIRLINE, FG2, TileLattice, Avatar, TopBar, avatarColor } from './components/design';
 
@@ -11,29 +13,30 @@ const MEDAL = [
 export const EndLeaderboard = () => {
   const navigate = useNavigate();
 
-  const [players] = useState([
-    { name: 'Fred', eliminatedRound: 8 },
-    { name: 'Gordon', eliminatedRound: 7 },
-    { name: 'Hannah', eliminatedRound: 7 },
-    { name: 'Zara', eliminatedRound: 2 },
-    { name: 'Yusuf', eliminatedRound: 2 },
-    { name: 'Mia', eliminatedRound: 2 },
-    { name: 'Noah', eliminatedRound: 1 },
-    { name: 'Priya', eliminatedRound: 1 },
-    { name: 'Luca', eliminatedRound: 1 },
-    { name: 'Amara', eliminatedRound: 2 },
-    { name: 'Tobias', eliminatedRound: 3 },
-    { name: 'Sienna', eliminatedRound: 4 },
-    { name: 'Kwame', eliminatedRound: 4 },
-    { name: 'Ingrid', eliminatedRound: 5 },
-    { name: 'Remy', eliminatedRound: 5 },
-    { name: 'Bashir', eliminatedRound: 6 },
-    ...Array.from({ length: 100 }, (_, i) => ({ name: `Player${i + 1}`, eliminatedRound: 3 })),
-  ]);
+  const players = useTracker(() => {
+    const sub = Meteor.subscribe('players');
 
-  const sorted = [...players].sort((a, b) => b.eliminatedRound - a.eliminatedRound);
-  const uniqueRounds = [...new Set(sorted.map((p) => p.eliminatedRound))].sort((a, b) => b - a);
-  const ranks = sorted.map((player) => uniqueRounds.indexOf(player.eliminatedRound));
+    if (!sub.ready()) {
+      return [];
+    }
+
+    return PlayersCollection.find({}).fetch().map((player) => ({
+      id: player._id,
+      name: player.name,
+      eliminatedRound: player.eliminatedRound ?? null,
+      isWinner: !!player.winner,
+    }));
+  }, []);
+
+  const sorted = [...players].sort((a, b) => {
+    if (a.isWinner && !b.isWinner) return -1;
+    if (!a.isWinner && b.isWinner) return 1;
+    return (b.eliminatedRound ?? 0) - (a.eliminatedRound ?? 0);
+  });
+
+  const rankKey = (player) => (player.isWinner ? 'winner' : player.eliminatedRound);
+  const uniqueRanks = [...new Set(sorted.map(rankKey))];
+  const ranks = sorted.map((player) => uniqueRanks.indexOf(rankKey(player)));
 
   // Group top-3 ranks into podium blocks, displayed as 2nd | 1st | 3rd
   const byRank = [0, 1, 2].map((rank) => sorted.filter((p) => ranks[sorted.indexOf(p)] === rank));
@@ -158,10 +161,10 @@ export const EndLeaderboard = () => {
           </div>
 
           {sorted
-            .filter((player) => uniqueRounds.indexOf(player.eliminatedRound) > 2)
+            .filter((player) => uniqueRanks.indexOf(rankKey(player)) > 2)
             .map((player, index) => {
-              const rank = uniqueRounds.indexOf(player.eliminatedRound);
-              const tied = sorted.filter((p) => p.eliminatedRound === player.eliminatedRound).length > 1;
+              const rank = uniqueRanks.indexOf(rankKey(player));
+              const tied = sorted.filter((p) => rankKey(p) === rankKey(player)).length > 1;
               const medal = MEDAL[rank];
               const rowColor = medal ? medal.color : 'oklch(0.93 0.01 270)';
               const rowDelay = 1.5 + index * 0.04;

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -260,7 +260,7 @@ export const EndLeaderboard = ({ gameId }) => {
             animation: 'homeButtonIn 0.55s ease 1.8s both',
           }}
         >
-          Back to Home
+          New Game
           <ArrowIcon size={14} stroke={PRIMARY} />
         </button>
       </div>

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -20,12 +20,15 @@ export const EndLeaderboard = ({ gameId }) => {
       return [];
     }
 
-    return PlayersCollection.find(gameId ? { gameId } : {}).fetch().map((player) => ({
-      id: player._id,
-      name: player.name,
-      eliminatedRound: player.eliminatedRound ?? null,
-      isWinner: !!player.winner,
-    }));
+    return PlayersCollection.find(gameId ? { gameId } : {})
+      .fetch()
+      .map((player) => ({
+        id: player._id,
+        name: player.name,
+        eliminatedRound: player.eliminatedRound ?? null,
+        longestStreak: player.longestStreak ?? 0,
+        isWinner: !!player.winner,
+      }));
   }, [gameId]);
 
   const sorted = [...players].sort((a, b) => {
@@ -76,7 +79,10 @@ export const EndLeaderboard = ({ gameId }) => {
       </div>
 
       <div className="relative z-10 flex flex-1 flex-col items-center px-6 pb-12">
-        <div className="mb-7 flex flex-col items-center text-center" style={{ animation: 'leaderboardTitleIn 0.7s ease both' }}>
+        <div
+          className="mb-7 flex flex-col items-center text-center"
+          style={{ animation: 'leaderboardTitleIn 0.7s ease both' }}
+        >
           <p className="mb-2 font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: PRIMARY }}>
             Final Results
           </p>
@@ -97,7 +103,7 @@ export const EndLeaderboard = ({ gameId }) => {
         </div>
 
         {/* Podium */}
-        <div className="w-full max-w-md flex items-end justify-center gap-3 mb-10">
+        <div className="mb-10 flex w-full max-w-md items-end justify-center gap-3">
           {podiumOrder.map((group, i) => {
             const medalIndex = i === 0 ? 1 : i === 1 ? 0 : 2;
             const medal = MEDAL[medalIndex];
@@ -184,70 +190,73 @@ export const EndLeaderboard = ({ gameId }) => {
 
         <div className="flex w-full max-w-md flex-col gap-2">
           {/* header */}
-          <div
-            className="mb-1 flex px-3"
-            style={{ animation: 'rowSlideIn 0.45s ease 1.35s both' }}
-          >
-              <span className="w-12 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-                Rank
-              </span>
-              <span className="flex-1 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-                Player
-              </span>
-              <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-                Score
-              </span>
-            </div>
+          <div className="mb-1 flex px-3" style={{ animation: 'rowSlideIn 0.45s ease 1.35s both' }}>
+            <span className="w-12 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+              Rank
+            </span>
+            <span className="flex-1 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+              Player
+            </span>
+            <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+              Score
+            </span>
+            <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+              Streak
+            </span>
+          </div>
 
-          {sorted
-            .map((player, index) => {
-              const rank = uniqueRanks.indexOf(rankKey(player));
-              const tied = sorted.filter((p) => rankKey(p) === rankKey(player)).length > 1;
-              const medal = MEDAL[rank];
-              const rowColor = medal ? medal.color : 'oklch(0.93 0.01 270)';
-              const rowDelay = 1.5 + index * 0.04;
+          {sorted.map((player, index) => {
+            const rank = uniqueRanks.indexOf(rankKey(player));
+            const tied = sorted.filter((p) => rankKey(p) === rankKey(player)).length > 1;
+            const medal = MEDAL[rank];
+            const rowColor = medal ? medal.color : 'oklch(0.93 0.01 270)';
+            const rowDelay = 1.5 + index * 0.04;
 
-              return (
-                <div
-                  key={player.name}
-                  className="flex items-center gap-3 rounded-xl px-3 py-3"
-                  style={{
-                    animation: `scoreboardRowIn 0.55s cubic-bezier(0.22,1,0.36,1) ${rowDelay}s both`,
-                    background: medal
-                      ? `color-mix(in oklab, ${medal.color} 12%, transparent)`
-                      : 'color-mix(in oklab, white 4%, transparent)',
-                    border: `1px solid ${
-                      medal
-                        ? `color-mix(in oklab, ${medal.color} 30%, transparent)`
-                        : `color-mix(in oklab, white 8%, transparent)`
-                    }`,
-                  }}
-                >
-                  <span className="w-12 shrink-0 font-outfit text-sm font-extrabold" style={{ color: rowColor }}>
-                    {tied ? '=' : ''}
-                    {rank + 1}
-                  </span>
+            return (
+              <div
+                key={player.name}
+                className="flex items-center gap-3 rounded-xl px-3 py-3"
+                style={{
+                  animation: `scoreboardRowIn 0.55s cubic-bezier(0.22,1,0.36,1) ${rowDelay}s both`,
+                  background: medal
+                    ? `color-mix(in oklab, ${medal.color} 12%, transparent)`
+                    : 'color-mix(in oklab, white 4%, transparent)',
+                  border: `1px solid ${
+                    medal
+                      ? `color-mix(in oklab, ${medal.color} 30%, transparent)`
+                      : `color-mix(in oklab, white 8%, transparent)`
+                  }`,
+                }}
+              >
+                <span className="w-12 shrink-0 font-outfit text-sm font-extrabold" style={{ color: rowColor }}>
+                  {tied ? '=' : ''}
+                  {rank + 1}
+                </span>
 
-                  <Avatar letter={player.name[0]} color={avatarColor(player.name)} size={32} />
+                <Avatar letter={player.name[0]} color={avatarColor(player.name)} size={32} />
 
-                  <span className="flex-1 font-outfit text-[15px] font-semibold" style={{ color: rowColor }}>
-                    {player.name}
-                    {rank === 0 && (
-                      <span
-                        className="ml-2 font-mono text-[10px] uppercase tracking-widest"
-                        style={{ color: PRIMARY, animation: 'winnerPulse 1.5s ease-in-out infinite' }}
-                      >
-                        Winner
-                      </span>
-                    )}
-                  </span>
+                <span className="flex-1 font-outfit text-[15px] font-semibold" style={{ color: rowColor }}>
+                  {player.name}
+                  {rank === 0 && (
+                    <span
+                      className="ml-2 font-mono text-[10px] uppercase tracking-widest"
+                      style={{ color: PRIMARY, animation: 'winnerPulse 1.5s ease-in-out infinite' }}
+                    >
+                      Winner
+                    </span>
+                  )}
+                </span>
 
-                  <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
-                    {player.isWinner ? `Won Rd ${playerScore(player)}` : `Rd ${playerScore(player)}`}
-                  </span>
-                </div>
-              );
-            })}
+                <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
+                  {player.isWinner ? `Won Rd ${playerScore(player)}` : `Rd ${playerScore(player)}`}
+                </span>
+
+                <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
+                  {player.longestStreak}
+                </span>
+              </div>
+            );
+          })}
         </div>
 
         <button

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -10,7 +10,7 @@ const MEDAL = [
   { color: 'oklch(0.72 0.14 55)', label: '3rd' },
 ];
 
-export const EndLeaderboard = () => {
+export const EndLeaderboard = ({ gameId }) => {
   const navigate = useNavigate();
 
   const players = useTracker(() => {
@@ -20,13 +20,13 @@ export const EndLeaderboard = () => {
       return [];
     }
 
-    return PlayersCollection.find({}).fetch().map((player) => ({
+    return PlayersCollection.find(gameId ? { gameId } : {}).fetch().map((player) => ({
       id: player._id,
       name: player.name,
       eliminatedRound: player.eliminatedRound ?? null,
       isWinner: !!player.winner,
     }));
-  }, []);
+  }, [gameId]);
 
   const sorted = [...players].sort((a, b) => {
     if (a.isWinner && !b.isWinner) return -1;

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { PlayersCollection } from '../api/players';
 import { useNavigate } from 'react-router-dom';
-import { BG, PRIMARY, TILE, HAIRLINE, FG2, TileLattice, Avatar, TopBar, avatarColor } from './components/design';
+import { BG, PRIMARY, FG2, TileLattice, Avatar, TopBar, ArrowIcon, avatarColor } from './components/design';
 
 const MEDAL = [
   { color: 'oklch(0.83 0.16 80)', label: '1st' },
@@ -42,6 +42,13 @@ export const EndLeaderboard = ({ gameId }) => {
   const byRank = [0, 1, 2].map((rank) => sorted.filter((p) => ranks[sorted.indexOf(p)] === rank));
   const podiumOrder = [byRank[1], byRank[0], byRank[2]];
   const podiumHeights = [72, 100, 56];
+  const winnerGroup = byRank[0] ?? [];
+  const highestEliminatedRound = Math.max(0, ...players.map((player) => player.eliminatedRound ?? 0));
+
+  const playerScore = (player) => {
+    if (player.isWinner) return Math.max(highestEliminatedRound, player.eliminatedRound ?? 0);
+    return player.eliminatedRound ?? 0;
+  };
 
   if (players.length === 0) {
     return (
@@ -69,13 +76,28 @@ export const EndLeaderboard = ({ gameId }) => {
       </div>
 
       <div className="relative z-10 flex flex-1 flex-col items-center px-6 pb-12">
-        <h1 className="mb-2 font-outfit text-5xl font-extrabold tracking-tight">Leaderboard</h1>
-        <p className="mb-8 font-mono text-[13px] uppercase tracking-widest" style={{ color: FG2 }}>
-          Final Results
-        </p>
+        <div className="mb-7 flex flex-col items-center text-center" style={{ animation: 'leaderboardTitleIn 0.7s ease both' }}>
+          <p className="mb-2 font-mono text-[11px] uppercase tracking-[0.22em]" style={{ color: PRIMARY }}>
+            Final Results
+          </p>
+          <h1 className="font-outfit text-5xl font-extrabold tracking-tight">Leaderboard</h1>
+          {winnerGroup.length > 0 && (
+            <div
+              className="mt-4 rounded-full px-4 py-2 font-outfit text-sm font-extrabold"
+              style={{
+                color: BG,
+                background: `linear-gradient(135deg, ${MEDAL[0].color}, ${PRIMARY})`,
+                boxShadow: `0 0 34px color-mix(in oklab, ${MEDAL[0].color} 28%, transparent)`,
+                animation: 'winnerCrown 1.1s cubic-bezier(0.22,1,0.36,1) 0.35s both',
+              }}
+            >
+              Winner: {winnerGroup.map((player) => player.name).join(' & ')}
+            </div>
+          )}
+        </div>
 
         {/* Podium */}
-        <div className="mb-10 flex w-full max-w-md items-end justify-center gap-3 overflow-hidden">
+        <div className="mb-10 flex w-full max-w-md items-end justify-center gap-3 overflow-hidden px-1">
           {podiumOrder.map((group, i) => {
             const medalIndex = i === 0 ? 1 : i === 1 ? 0 : 2;
             const medal = MEDAL[medalIndex];
@@ -146,7 +168,11 @@ export const EndLeaderboard = ({ gameId }) => {
                     border: `1px solid color-mix(in oklab, ${medal.color} 35%, transparent)`,
                     borderBottom: 'none',
                     color: medal.color,
-                    animation: `podiumRise 0.6s cubic-bezier(0.22,1,0.36,1) ${riseDelay}s both`,
+                    boxShadow:
+                      medalIndex === 0
+                        ? `0 -16px 34px -22px color-mix(in oklab, ${medal.color} 60%, transparent)`
+                        : 'none',
+                    animation: `podiumRise 0.75s cubic-bezier(0.22,1,0.36,1) ${riseDelay}s both`,
                   }}
                 >
                   {group.length > 1 ? `=${medalIndex + 1}` : medalIndex + 1}
@@ -158,8 +184,10 @@ export const EndLeaderboard = ({ gameId }) => {
 
         <div className="flex w-full max-w-md flex-col gap-2">
           {/* header */}
-          {sorted.some((player) => uniqueRanks.indexOf(rankKey(player)) > 2) && (
-            <div className="mb-1 flex px-3">
+          <div
+            className="mb-1 flex px-3"
+            style={{ animation: 'rowSlideIn 0.45s ease 1.35s both' }}
+          >
               <span className="w-12 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
                 Rank
               </span>
@@ -167,13 +195,11 @@ export const EndLeaderboard = ({ gameId }) => {
                 Player
               </span>
               <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-                Round
+                Score
               </span>
             </div>
-          )}
 
           {sorted
-            .filter((player) => uniqueRanks.indexOf(rankKey(player)) > 2)
             .map((player, index) => {
               const rank = uniqueRanks.indexOf(rankKey(player));
               const tied = sorted.filter((p) => rankKey(p) === rankKey(player)).length > 1;
@@ -186,7 +212,7 @@ export const EndLeaderboard = ({ gameId }) => {
                   key={player.name}
                   className="flex items-center gap-3 rounded-xl px-3 py-3"
                   style={{
-                    animation: `rowSlideIn 0.4s ease ${rowDelay}s both`,
+                    animation: `scoreboardRowIn 0.55s cubic-bezier(0.22,1,0.36,1) ${rowDelay}s both`,
                     background: medal
                       ? `color-mix(in oklab, ${medal.color} 12%, transparent)`
                       : 'color-mix(in oklab, white 4%, transparent)',
@@ -217,12 +243,26 @@ export const EndLeaderboard = ({ gameId }) => {
                   </span>
 
                   <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
-                    {player.isWinner ? 'Winner' : `Rd ${player.eliminatedRound}`}
+                    {player.isWinner ? `Won Rd ${playerScore(player)}` : `Rd ${playerScore(player)}`}
                   </span>
                 </div>
               );
             })}
         </div>
+
+        <button
+          onClick={() => navigate('/play')}
+          className="mt-8 inline-flex items-center gap-2 rounded-full px-5 py-3 font-outfit text-[13px] font-extrabold uppercase tracking-[0.16em] transition-transform hover:scale-[1.02]"
+          style={{
+            background: `color-mix(in oklab, ${PRIMARY} 16%, transparent)`,
+            border: `1px solid color-mix(in oklab, ${PRIMARY} 48%, transparent)`,
+            color: PRIMARY,
+            animation: 'homeButtonIn 0.55s ease 1.8s both',
+          }}
+        >
+          Back to Home
+          <ArrowIcon size={14} stroke={PRIMARY} />
+        </button>
       </div>
     </div>
   );

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -43,6 +43,14 @@ export const EndLeaderboard = () => {
   const podiumOrder = [byRank[1], byRank[0], byRank[2]];
   const podiumHeights = [72, 100, 56];
 
+  if (players.length === 0) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-bg text-fg">
+        <p className="font-mono text-sm uppercase tracking-widest">No leaderboard results yet</p>
+      </div>
+    );
+  }
+
   return (
     <div
       className="relative flex min-h-screen w-full flex-col"
@@ -122,11 +130,13 @@ export const EndLeaderboard = () => {
                     animation: `avatarPop 0.4s cubic-bezier(0.34,1.56,0.64,1) ${avatarDelay + 0.1}s both`,
                   }}
                 >
-                  {medalIndex === 0
-                    ? `Winner · Rd ${group[0].eliminatedRound}`
+                  {group[0].isWinner
+                    ? 'Winner · Last Standing'
                     : medalIndex === 1
                       ? `Runner-up · Rd ${group[0].eliminatedRound}`
-                      : `Third · Rd ${group[0].eliminatedRound}`}
+                      : medalIndex === 2
+                        ? `Third · Rd ${group[0].eliminatedRound}`
+                        : `Rd ${group[0].eliminatedRound}`}
                 </span>
                 <div
                   className="flex w-full items-center justify-center rounded-t-xl font-outfit text-lg font-extrabold"
@@ -148,17 +158,19 @@ export const EndLeaderboard = () => {
 
         <div className="flex w-full max-w-md flex-col gap-2">
           {/* header */}
-          <div className="mb-1 flex px-3">
-            <span className="w-12 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-              Rank
-            </span>
-            <span className="flex-1 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-              Player
-            </span>
-            <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
-              Round
-            </span>
-          </div>
+          {sorted.some((player) => uniqueRanks.indexOf(rankKey(player)) > 2) && (
+            <div className="mb-1 flex px-3">
+              <span className="w-12 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+                Rank
+              </span>
+              <span className="flex-1 font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+                Player
+              </span>
+              <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+                Round
+              </span>
+            </div>
+          )}
 
           {sorted
             .filter((player) => uniqueRanks.indexOf(rankKey(player)) > 2)
@@ -205,7 +217,7 @@ export const EndLeaderboard = () => {
                   </span>
 
                   <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
-                    {rank === 0 ? '—' : `Rd ${player.eliminatedRound}`}
+                    {player.isWinner ? 'Winner' : `Rd ${player.eliminatedRound}`}
                   </span>
                 </div>
               );

--- a/app/imports/ui/EndLeaderboard.jsx
+++ b/app/imports/ui/EndLeaderboard.jsx
@@ -15,6 +15,11 @@ function ordinal(rank) {
   return `${rank}${suffix}`;
 }
 
+function accuracyPercent(player) {
+  if (!player.totalGuesses) return 0;
+  return Math.round((player.correctGuesses / player.totalGuesses) * 100);
+}
+
 export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
   const navigate = useNavigate();
 
@@ -32,6 +37,8 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
         name: player.name,
         eliminatedRound: player.eliminatedRound ?? null,
         longestStreak: player.longestStreak ?? 0,
+        totalGuesses: player.totalGuesses ?? 0,
+        correctGuesses: player.correctGuesses ?? 0,
         isWinner: !!player.winner,
       }));
   }, [gameId]);
@@ -99,15 +106,29 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
           <h1 className="font-outfit text-5xl font-extrabold tracking-tight">Leaderboard</h1>
           {currentRank && (
             <div
-              className="mt-4 rounded-full px-4 py-2 font-outfit text-sm font-extrabold"
-              style={{
-                color: PRIMARY,
-                background: `color-mix(in oklab, ${PRIMARY} 16%, transparent)`,
-                border: `1px solid color-mix(in oklab, ${PRIMARY} 42%, transparent)`,
-                animation: 'winnerCrown 1.1s cubic-bezier(0.22,1,0.36,1) 0.2s both',
-              }}
+              className="mt-4 flex flex-col items-center gap-2"
+              style={{ animation: 'winnerCrown 1.1s cubic-bezier(0.22,1,0.36,1) 0.2s both' }}
             >
-              {currentRankIsTied ? `You tied for ${ordinal(currentRank)}` : `You came ${ordinal(currentRank)}`}
+              <div
+                className="rounded-full px-4 py-2 font-outfit text-sm font-extrabold"
+                style={{
+                  color: PRIMARY,
+                  background: `color-mix(in oklab, ${PRIMARY} 16%, transparent)`,
+                  border: `1px solid color-mix(in oklab, ${PRIMARY} 42%, transparent)`,
+                }}
+              >
+                {currentRankIsTied ? `You tied for ${ordinal(currentRank)}` : `You came ${ordinal(currentRank)}`}
+              </div>
+              <div
+                className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest"
+                style={{ color: FG2 }}
+              >
+                <span>Accuracy {accuracyPercent(currentPlayer)}%</span>
+                <span style={{ color: 'oklch(0.42 0.02 270)' }}>·</span>
+                <span>
+                  {currentPlayer.correctGuesses}/{currentPlayer.totalGuesses} correct
+                </span>
+              </div>
             </div>
           )}
           {winnerGroup.length > 0 && (
@@ -226,6 +247,9 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
             <span className="w-24 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
               Streak
             </span>
+            <span className="w-20 text-right font-mono text-[10px] uppercase tracking-widest" style={{ color: FG2 }}>
+              Acc
+            </span>
           </div>
 
           {sorted.map((player, index) => {
@@ -294,6 +318,10 @@ export const EndLeaderboard = ({ gameId, currentPlayerId }) => {
 
                 <span className="w-24 text-right font-mono text-sm" style={{ color: FG2 }}>
                   {player.longestStreak}
+                </span>
+
+                <span className="w-20 text-right font-mono text-sm" style={{ color: FG2 }}>
+                  {accuracyPercent(player)}%
                 </span>
               </div>
             );

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -142,6 +142,8 @@ export const GamePage = () => {
   }
 
   if (player?.eliminated) {
+    const longestStreak = player.longestStreak ?? 0;
+
     return (
       <div
         style={{
@@ -149,12 +151,40 @@ export const GamePage = () => {
           background: '#000',
           color: 'white',
           display: 'flex',
+          flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          fontSize: '2rem',
+          textAlign: 'center',
+          padding: '24px',
         }}
       >
-        <h1 style={{ fontSize: '3rem', marginBottom: '10px' }}>💀 GAME OVER</h1>
+        <h1 style={{ fontSize: '3rem', marginBottom: '18px' }}>GAME OVER</h1>
+        <div
+          style={{
+            border: '1px solid rgba(255,255,255,0.18)',
+            borderRadius: '14px',
+            padding: '18px 24px',
+            background: 'rgba(255,255,255,0.08)',
+            minWidth: '220px',
+          }}
+        >
+          <p
+            style={{
+              color: '#aaa',
+              fontSize: '0.75rem',
+              fontWeight: 'bold',
+              letterSpacing: '3px',
+              marginBottom: '8px',
+              textTransform: 'uppercase',
+            }}
+          >
+            Longest Streak
+          </p>
+          <p style={{ color: '#ffd369', fontSize: '3rem', fontWeight: 'bold', lineHeight: 1 }}>{longestStreak}</p>
+          <p style={{ color: '#ccc', fontSize: '0.9rem', marginTop: '8px' }}>
+            {longestStreak === 1 ? 'round correct in a row' : 'rounds correct in a row'}
+          </p>
+        </div>
       </div>
     );
   }

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -138,7 +138,7 @@ export const GamePage = () => {
   if (!player) return null;
 
   if (player?.gameFinished) {
-    return <EndLeaderboard gameId={player.gameId} />;
+    return <EndLeaderboard gameId={player.gameId} currentPlayerId={player._id} />;
   }
 
   if (player?.eliminated) {

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -20,6 +20,7 @@ export const GamePage = () => {
   const location = useLocation();
   const playerNameFromLobby = location.state?.playerName || 'Demo Player';
   const roomPin = location.state?.pin;
+  const gameId = roomPin || 'demo';
 
   useEffect(() => {
     const roundsSub = Meteor.subscribe('rounds');
@@ -31,8 +32,8 @@ export const GamePage = () => {
   }, []);
 
   const round = useTracker(() => {
-    return RoundsCollection.findOne({ isCurrent: true });
-  });
+    return RoundsCollection.findOne({ gameId, isCurrent: true });
+  }, [gameId]);
 
   const player = useTracker(() => {
     if (!playerId) return null;
@@ -41,7 +42,7 @@ export const GamePage = () => {
 
   useEffect(() => {
     if (!round?._id || playerId) return;
-    Meteor.call('players.join', round._id, playerNameFromLobby, (error, result) => {
+    Meteor.call('players.join', round._id, playerNameFromLobby, gameId, (error, result) => {
       if (error) {
         console.error(error);
         setMessage('Could not join the game.');
@@ -137,7 +138,7 @@ export const GamePage = () => {
   if (!player) return null;
 
   if (player?.gameFinished) {
-    return <EndLeaderboard />;
+    return <EndLeaderboard gameId={player.gameId} />;
   }
 
   if (player?.eliminated) {

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -136,7 +136,7 @@ export const GamePage = () => {
 
   if (!player) return null;
 
-  if (player?.winner) {
+  if (player?.gameFinished) {
     return <EndLeaderboard />;
   }
 

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -143,6 +143,9 @@ export const GamePage = () => {
 
   if (player?.eliminated) {
     const longestStreak = player.longestStreak ?? 0;
+    const totalGuesses = player.totalGuesses ?? 0;
+    const correctGuesses = player.correctGuesses ?? 0;
+    const accuracy = totalGuesses > 0 ? Math.round((correctGuesses / totalGuesses) * 100) : 0;
 
     return (
       <div
@@ -183,6 +186,29 @@ export const GamePage = () => {
           <p style={{ color: '#ffd369', fontSize: '3rem', fontWeight: 'bold', lineHeight: 1 }}>{longestStreak}</p>
           <p style={{ color: '#ccc', fontSize: '0.9rem', marginTop: '8px' }}>
             {longestStreak === 1 ? 'round correct in a row' : 'rounds correct in a row'}
+          </p>
+          <div
+            style={{
+              height: '1px',
+              background: 'rgba(255,255,255,0.12)',
+              margin: '16px 0 14px',
+            }}
+          />
+          <p
+            style={{
+              color: '#aaa',
+              fontSize: '0.75rem',
+              fontWeight: 'bold',
+              letterSpacing: '3px',
+              marginBottom: '8px',
+              textTransform: 'uppercase',
+            }}
+          >
+            Accuracy
+          </p>
+          <p style={{ color: '#9ce8ff', fontSize: '2rem', fontWeight: 'bold', lineHeight: 1 }}>{accuracy}%</p>
+          <p style={{ color: '#ccc', fontSize: '0.9rem', marginTop: '8px' }}>
+            {correctGuesses}/{totalGuesses} correct guesses
           </p>
         </div>
       </div>

--- a/app/imports/ui/pages/Splash.jsx
+++ b/app/imports/ui/pages/Splash.jsx
@@ -61,15 +61,6 @@ export function Splash() {
       {/* top bar */}
       <div className="relative flex shrink-0 justify-between px-7 py-5">
         <span className="font-outfit text-2xl font-extrabold tracking-tight text-fg">KIMPLY</span>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate('/leaderboard');
-          }}
-          className="font-mono text-[11px] uppercase tracking-widest text-fg3 transition-colors hover:text-fg"
-        >
-          Leaderboard
-        </button>
       </div>
 
       {/* hero */}

--- a/app/imports/ui/styles.css
+++ b/app/imports/ui/styles.css
@@ -35,12 +35,16 @@
 }
 
 @keyframes podiumRise {
-  from {
-    transform: translateY(100%);
+  0% {
+    transform: translateY(100%) scaleY(0.82);
     opacity: 0;
   }
-  to {
-    transform: translateY(0);
+  70% {
+    transform: translateY(-8px) scaleY(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scaleY(1);
     opacity: 1;
   }
 }
@@ -65,6 +69,58 @@
 @keyframes rowSlideIn {
   from {
     transform: translateY(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes leaderboardTitleIn {
+  from {
+    transform: translateY(-14px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes winnerCrown {
+  0% {
+    transform: translateY(12px) scale(0.86);
+    opacity: 0;
+  }
+  60% {
+    transform: translateY(-4px) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes scoreboardRowIn {
+  0% {
+    transform: translateX(-18px) scale(0.98);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(3px) scale(1.01);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes homeButtonIn {
+  from {
+    transform: translateY(12px);
     opacity: 0;
   }
   to {

--- a/app/tests/accuracy.test.js
+++ b/app/tests/accuracy.test.js
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import { Meteor } from 'meteor/meteor';
+import '../imports/api/gameMethods.js';
+import { PlayersCollection } from '../imports/api/players.js';
+import { RoundsCollection } from '../imports/api/rounds.js';
+
+if (Meteor.isServer) {
+  describe('Player accuracy tracking', function () {
+    let roundId;
+    let playerId;
+
+    const correctSequence = ['red', 'blue', 'green', 'yellow'];
+    const wrongSequence = ['blue', 'blue', 'blue', 'blue'];
+
+    beforeEach(async function () {
+      await PlayersCollection.removeAsync({});
+      await RoundsCollection.removeAsync({});
+
+      roundId = await RoundsCollection.insertAsync({
+        gameId: 'accuracy-test',
+        lengthOfSequence: 4,
+        sequence: correctSequence,
+        createdAt: new Date(),
+        advanced: false,
+        isCurrent: true,
+      });
+
+      playerId = await Meteor.callAsync('players.join', roundId, 'Accuracy Player', 'accuracy-test');
+    });
+
+    it('starts new players with zero total and correct guesses', async function () {
+      const player = await PlayersCollection.findOneAsync(playerId);
+
+      assert.strictEqual(player.totalGuesses, 0);
+      assert.strictEqual(player.correctGuesses, 0);
+    });
+
+    it('counts a correct sequence as one total guess and one correct guess', async function () {
+      await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.totalGuesses, 1);
+      assert.strictEqual(player.correctGuesses, 1);
+    });
+
+    it('counts a wrong sequence as one total guess and no correct guesses', async function () {
+      await Meteor.callAsync('players.submitSequence', playerId, wrongSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.totalGuesses, 1);
+      assert.strictEqual(player.correctGuesses, 0);
+    });
+
+    it('tracks mixed attempts across wrong and correct guesses', async function () {
+      await Meteor.callAsync('players.submitSequence', playerId, wrongSequence);
+      await Meteor.callAsync('players.submitSequence', playerId, wrongSequence);
+      await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.totalGuesses, 3);
+      assert.strictEqual(player.correctGuesses, 1);
+    });
+  });
+}

--- a/app/tests/lifeDeduction.test.js
+++ b/app/tests/lifeDeduction.test.js
@@ -24,6 +24,8 @@ describe('Life Deduction', () => {
       name: 'Test Player',
       lives: 3,
       attemptedSequence: [],
+      currentStreak: 0,
+      longestStreak: 0,
       eliminated: false,
       winner: false,
       completeRound: false,
@@ -54,6 +56,30 @@ describe('Life Deduction', () => {
       await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
       const player = await PlayersCollection.findOneAsync(playerId);
       assert.strictEqual(player.lives, 3);
+    });
+
+    it('correct guess increases current and longest streak', async () => {
+      const correctSequence = ['red', 'blue', 'green', 'yellow'];
+      await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.currentStreak, 1);
+      assert.strictEqual(player.longestStreak, 1);
+    });
+
+    it('incorrect guess resets current streak and keeps longest streak', async () => {
+      await PlayersCollection.updateAsync(playerId, {
+        $set: {
+          currentStreak: 2,
+          longestStreak: 2,
+        },
+      });
+
+      const wrongSequence = ['blue', 'blue', 'blue', 'blue'];
+      await Meteor.callAsync('players.submitSequence', playerId, wrongSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.currentStreak, 0);
+      assert.strictEqual(player.longestStreak, 2);
     });
   }
 });

--- a/app/tests/streak.test.js
+++ b/app/tests/streak.test.js
@@ -1,0 +1,76 @@
+import assert from 'assert';
+import { Meteor } from 'meteor/meteor';
+import '../imports/api/gameMethods.js';
+import { PlayersCollection } from '../imports/api/players.js';
+import { RoundsCollection } from '../imports/api/rounds.js';
+
+if (Meteor.isServer) {
+  describe('Player streak tracking', function () {
+    let roundId;
+    let playerId;
+
+    const correctSequence = ['red', 'blue', 'green', 'yellow'];
+    const wrongSequence = ['blue', 'blue', 'blue', 'blue'];
+
+    beforeEach(async function () {
+      await PlayersCollection.removeAsync({});
+      await RoundsCollection.removeAsync({});
+
+      roundId = await RoundsCollection.insertAsync({
+        gameId: 'streak-test',
+        lengthOfSequence: 4,
+        sequence: correctSequence,
+        createdAt: new Date(),
+        advanced: false,
+        isCurrent: true,
+      });
+
+      playerId = await Meteor.callAsync('players.join', roundId, 'Streak Player', 'streak-test');
+    });
+
+    it('starts new players with zero current and longest streak', async function () {
+      const player = await PlayersCollection.findOneAsync(playerId);
+
+      assert.strictEqual(player.currentStreak, 0);
+      assert.strictEqual(player.longestStreak, 0);
+    });
+
+    it('increments current and longest streak after a correct guess', async function () {
+      await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.currentStreak, 1);
+      assert.strictEqual(player.longestStreak, 1);
+    });
+
+    it('resets current streak after a wrong guess but keeps the longest streak', async function () {
+      await PlayersCollection.updateAsync(playerId, {
+        $set: {
+          currentStreak: 3,
+          longestStreak: 3,
+        },
+      });
+
+      await Meteor.callAsync('players.submitSequence', playerId, wrongSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.currentStreak, 0);
+      assert.strictEqual(player.longestStreak, 3);
+    });
+
+    it('updates longest streak when the new current streak beats the previous best', async function () {
+      await PlayersCollection.updateAsync(playerId, {
+        $set: {
+          currentStreak: 3,
+          longestStreak: 3,
+        },
+      });
+
+      await Meteor.callAsync('players.submitSequence', playerId, correctSequence);
+
+      const player = await PlayersCollection.findOneAsync(playerId);
+      assert.strictEqual(player.currentStreak, 4);
+      assert.strictEqual(player.longestStreak, 4);
+    });
+  });
+}


### PR DESCRIPTION
This PR connects the final leaderboard to real player data and scopes results by gameId.

Changes:
- Added gameId to rounds, players, and leaderboard entries.
- Updated EndLeaderboard to filter players by gameId.
- Added eliminatedRound tracking.
- Added gameFinished handling so final results can show after the game ends.
- Improved handling for tied final-round eliminations.
- Added new game button to the leaderboard to return to starting game page
- Added animation to the winner
- Added the team's MIT license