### PR TITLE
fix: stop room code input dropping the first keystroke (Closes #57)

### DIFF
--- a/app/imports/ui/pages/JoinRoom.jsx
+++ b/app/imports/ui/pages/JoinRoom.jsx
@@ -28,9 +28,13 @@ export function JoinRoom() {
   };
 
   const handleInput = (e) => {
-    setCode((prev) => appendRoomCodeInput(prev, e.target.value, SLOTS));
-    setError('');
+    // Read the typed value before clearing: clearCapturedInput blanks e.target.value
+    // synchronously, and React may evaluate the setCode updater afterwards, which would
+    // otherwise read '' and drop the keystroke (forcing users to type each letter twice).
+    const typed = e.target.value;
     clearCapturedInput(e);
+    setCode((prev) => appendRoomCodeInput(prev, typed, SLOTS));
+    setError('');
   };
 
   const handleJoin = () => {

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -20,6 +20,13 @@ This file is the source of truth for **why** any of that is the way it is.
 
 ---
 
+## 2026-08-31 - Fixed the room-code input dropping keystrokes (D15)
+
+`JoinRoom.handleInput` passed a functional updater to `setCode` that read `e.target.value`, then cleared that same value synchronously with `clearCapturedInput(e)` further down the handler.
+React only evaluates a functional updater eagerly when the fiber has no pending work; otherwise it defers the updater until render, by which point the clear has already blanked `e.target.value`, so `appendRoomCodeInput` received `''` and the keystroke was lost. That is why players had to type each code letter twice.
+The fix reads the typed value into a local before clearing and references that local inside the updater, so the update no longer depends on the mutated DOM node. The non-obvious part: reordering `clearCapturedInput` above `setCode` is not cosmetic — it removes a read-after-mutate race, not just a style preference.
+Files: `app/imports/ui/pages/JoinRoom.jsx`, `docs/defect-register.md` (D15).
+
 ## 2026-08-29 - Skills are workflows, not product rules
 
 Every skill under `.agents/skills/` was rewritten to drop game-specific rules (defect IDs, publication invariants, route tables, "do not add a login wall", lives / sequences / `'demo'` gameId).

--- a/docs/defect-register.md
+++ b/docs/defect-register.md
@@ -10,7 +10,7 @@ Keep the two in step: an ID means the same thing in both files, or neither file 
 
 There is no D13. The register and the summary table had drifted by one on the last three IDs; reconciling them on 2026-08-29 onto the summary table's numbering left the gap. Do not renumber to close it - the IDs are cited from skills and pull requests.
 
-**Last verified:** 2026-08-29
+**Last verified:** 2026-08-31
 
 ---
 
@@ -246,6 +246,24 @@ Prettier is the only style gate in this repository (there is no ESLint), and it 
 The cost of leaving it is that every branch inherits the dirt, so no diff can be trusted to be formatting-clean.
 
 **Fix:** one dedicated commit that runs `meteor npm run format` and changes nothing else, so it can be reviewed as a no-op and skipped in `git blame`.
+
+---
+
+## D15 - Room code input drops keystrokes - **fixed 2026-08-31**
+
+On `/play/join`, `JoinRoom.handleInput` read the freshly typed character inside a `setCode` functional updater, then cleared the hidden capture input in the same handler:
+
+```js
+setCode((prev) => appendRoomCodeInput(prev, e.target.value, SLOTS));
+setError('');
+clearCapturedInput(e); // e.target.value = ''
+```
+
+React evaluates a `useState` functional updater eagerly only when the fiber has no pending work. When it cannot (fast typing, or a render already scheduled), the updater runs at render time - after `clearCapturedInput` has blanked `e.target.value` - so `appendRoomCodeInput` appends `''` and the keystroke is lost. Players saw the first letter (and intermittently later ones) vanish and had to type the code twice.
+
+**Fix (applied):** capture `e.target.value` into a local, clear the input, then update state from the local so the updater never depends on the mutated DOM node. `app/imports/ui/pages/JoinRoom.jsx:30`.
+
+The ID is D15 because D13 is a deliberate gap (see the note at the top of this file).
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes the Join Room code entry dropping keystrokes, which forced players to type each code letter twice before it registered.
- `JoinRoom.handleInput` read `e.target.value` inside a `setCode` functional updater, then blanked that same value with `clearCapturedInput(e)` in the same handler. React defers a functional updater to render time whenever the fiber has pending work, so the updater ran **after** the clear and appended `''`, losing the keystroke.
- The fix captures the typed value into a local, clears the input, then updates state from the local — the update no longer depends on the mutated DOM node.
- Recorded as **D15** in `docs/defect-register.md` and `docs/decision-log.md`, per the repo's doc-in-step rule.

Closes #57

## Test plan
- [ ] On `/play/join`, type a 5-character code at normal and fast speed — every character registers on the first keypress, no doubling.
- [ ] Backspace still removes the last character.
- [ ] Opening an invite link with `?code=ABCDE` still prefills the slots.
- [ ] `Enter` still submits when the code and username are complete.
- [ ] Existing `uiHelpers.test.js` (roomCode/keyboard pure helpers) still passes; the change is a handler reorder, not a helper change.

## Note for reviewer
This gh CLI lacks `gh issue develop`, so the branch was cut from `origin/dev` directly rather than through the issue's Development sidebar. The `Closes #57` above provides the native "will close this issue" link; if you want the branch itself listed under the issue, link it via issue #57 → **Development**.
