### PR TITLE
fix: lock tile input while the sequence replays after a wrong guess (Closes #60)

### DIFF
--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -150,7 +150,11 @@ export const GamePage = () => {
           setShake(true);
           setTimeout(() => setShake(false), 400);
           setAttemptedSequence([]);
-          setPlayerCanInput(true);
+          // Keep input locked while the sequence replays, otherwise the tiles stay
+          // clickable and the player can copy the answer as it lights up. The replay
+          // (triggered by the replayKey bump) re-enables input via onSequenceComplete
+          // once it finishes, exactly like a fresh round does.
+          setPlayerCanInput(false);
           setReplayKey((prev) => prev + 1);
         }
       }

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -20,6 +20,12 @@ This file is the source of truth for **why** any of that is the way it is.
 
 ---
 
+## 2026-08-31 - Locked tile input during the post-mistake sequence replay (D16)
+
+After a wrong guess with lives remaining, `GamePage.handleSubmit` set `playerCanInput` to `true` and bumped `replayKey` in the same breath, so the colour tiles stayed clickable while the sequence replayed and a player could copy the answer as each tile lit up.
+Set `playerCanInput` to `false` on the retry path and let `onSequenceComplete` re-enable it after the replay, matching the fresh-round flow. Non-obvious: the retry replay reuses the same `roundId`, so re-enabling has to be driven by the replay finishing, not by a round change.
+Files: `app/imports/ui/pages/GamePage.jsx`, `docs/defect-register.md` (D16).
+
 ## 2026-08-29 - Skills are workflows, not product rules
 
 Every skill under `.agents/skills/` was rewritten to drop game-specific rules (defect IDs, publication invariants, route tables, "do not add a login wall", lives / sequences / `'demo'` gameId).

--- a/docs/defect-register.md
+++ b/docs/defect-register.md
@@ -249,6 +249,22 @@ The cost of leaving it is that every branch inherits the dirt, so no diff can be
 
 ---
 
+## D16 - Tiles clickable during the post-mistake sequence replay - **fixed 2026-08-31**
+
+On a wrong guess with lives left, `GamePage.handleSubmit` re-enabled input and restarted the sequence replay together:
+
+```js
+setAttemptedSequence([]);
+setPlayerCanInput(true);
+setReplayKey((prev) => prev + 1);
+```
+
+`replayKey` restarts `ColourSequence` playback, but `playerCanInput` was already `true`, so the tiles accepted clicks throughout the replay - a player could click each tile as it lit up and copy the answer. A fresh round instead starts with input disabled and only re-enables it from `onSequenceComplete`.
+
+**Fix (applied):** set `playerCanInput` to `false` on the retry path; the replay re-enables input via `onSequenceComplete` when it finishes. `app/imports/ui/pages/GamePage.jsx`.
+
+---
+
 ## Structural issues that are not bugs but shape future work
 
 **Duplicated sequence generator.** `generateSequence` exists identically in `imports/api/sequence.js:9` and `imports/api/gameMethods.js:9`.


### PR DESCRIPTION
## Summary
- Fixes a cheat: after a wrong guess, the colour tiles stayed clickable while the sequence replayed, so a player could click each tile as it lit up and copy the answer.
- `handleSubmit` set `playerCanInput` to `true` and bumped `replayKey` together; the replay ran with input enabled. Now the retry path sets `playerCanInput` to `false`, and `onSequenceComplete` re-enables it once the replay finishes — the same flow a fresh round uses.
- Recorded as **D16** in `docs/defect-register.md` and `docs/decision-log.md`.

Closes #60

## Test plan
- [ ] Start a round, submit a wrong sequence with lives remaining.
- [ ] While the sequence replays, the colour tiles are not clickable.
- [ ] After the replay finishes, input re-enables and you can attempt again.
- [ ] First-round playback still locks input until the sequence finishes.
