### PR TITLE
fix: show the full starting-lives track and grey out lost lives (Closes #61)

### DIFF
--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -69,7 +69,9 @@ export const GamePage = () => {
     return RoundsCollection.findOne({ gameId, isCurrent: true });
   }, [gameId, player?.roundId]);
 
-  const totalLives = room?.gameMode === 'custom' ? (room.customSettings?.startingLives ?? 3) : 3;
+  // startingLives is copied into customSettings for every preset mode (easy=5, hard=1, ...),
+  // not just 'custom', so size the lives track off customSettings regardless of gameMode.
+  const totalLives = room?.customSettings?.startingLives ?? 3;
 
   useEffect(() => {
     if (!round?._id || playerId) return;
@@ -344,19 +346,19 @@ export const GamePage = () => {
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
         {/* Lives display */}
         <div style={{ display: 'flex', justifyContent: 'flex-start', gap: '1vw', marginBottom: '2vh' }}>
-          {Array.from({ length: Math.max(player?.lives ?? 3, 3) }, (_, i) => i + 1).map((heart) => (
+          {Array.from({ length: totalLives }, (_, i) => i + 1).map((heart) => (
             <div
               key={heart}
               style={{
                 width: 'clamp(60px, 8vw, 80px)',
                 height: 'clamp(60px, 8vw, 80px)',
-                backgroundColor: heart <= (player?.lives ?? 3) ? '#e03030' : '#333',
+                backgroundColor: heart <= (player?.lives ?? totalLives) ? '#e03030' : '#333',
                 borderRadius: '50%',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
                 fontSize: 'clamp(30px, 4vw, 32px)',
-                boxShadow: heart <= (player?.lives ?? 3) ? '0 0 10px #e0303088' : 'none',
+                boxShadow: heart <= (player?.lives ?? totalLives) ? '0 0 10px #e0303088' : 'none',
                 transition: 'all 0.3s ease',
               }}
             >

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -20,6 +20,12 @@ This file is the source of truth for **why** any of that is the way it is.
 
 ---
 
+## 2026-08-31 - Lives display now shows the full starting-lives track (D17)
+
+The game page sized its hearts off `Math.max(player.lives, 3)` and computed `totalLives` only for `gameMode === 'custom'`, so preset modes (easy = 5 lives, etc.) fell back to 3 and a lost life removed a heart instead of greying it out.
+`customSettings.startingLives` is populated for every preset, so `totalLives` now reads it regardless of mode and the display renders a fixed `totalLives` track, greying circles above the current life count. `players.join` already stores the correct starting lives, so this was display-only.
+Files: `app/imports/ui/pages/GamePage.jsx`, `docs/defect-register.md` (D17).
+
 ## 2026-08-29 - Skills are workflows, not product rules
 
 Every skill under `.agents/skills/` was rewritten to drop game-specific rules (defect IDs, publication invariants, route tables, "do not add a login wall", lives / sequences / `'demo'` gameId).

--- a/docs/defect-register.md
+++ b/docs/defect-register.md
@@ -249,6 +249,20 @@ The cost of leaving it is that every branch inherits the dirt, so no diff can be
 
 ---
 
+## D17 - Lives display hardcoded to 3 and shrinks instead of greying out - **fixed 2026-08-31**
+
+`GamePage` computed `totalLives` only for the `'custom'` mode:
+
+```js
+const totalLives = room?.gameMode === 'custom' ? (room.customSettings?.startingLives ?? 3) : 3;
+```
+
+but preset modes (`easy`, `medium`, `hard`, `battle_royale`) also store their lives in `customSettings.startingLives` and are not `'custom'`, so this fell back to 3. The heart track also ignored `totalLives` and sized itself off `Math.max(player.lives, 3)`, so losing a life removed a circle rather than greying it out. `players.join` already sets `lives: startingLives`, so the value was right - only the display was wrong.
+
+**Fix (applied):** read `totalLives` from `customSettings.startingLives` for every mode, render a fixed `totalLives`-circle track, and grey circles above the current life count. `app/imports/ui/pages/GamePage.jsx`.
+
+---
+
 ## Structural issues that are not bugs but shape future work
 
 **Duplicated sequence generator.** `generateSequence` exists identically in `imports/api/sequence.js:9` and `imports/api/gameMethods.js:9`.


### PR DESCRIPTION
## Summary
- Fixes the lives display: it showed 3 hearts regardless of mode and *removed* a heart when a life was lost instead of greying it out.
- Root cause: `totalLives` was only read from `customSettings.startingLives` for `gameMode === 'custom'` (preset modes like `easy`=5 are not `'custom'`, so it fell back to 3), and the display sized its track off `Math.max(player.lives, 3)` rather than `totalLives`.
- Now `totalLives` reads `customSettings.startingLives` for every mode, and the display renders a fixed `totalLives`-circle track, greying circles above the current life count. `players.join` already stores the correct starting lives, so this is a display-only change.
- Recorded as **D17** in `docs/defect-register.md` and `docs/decision-log.md`.

Closes #61

## Test plan
- [ ] Start an `easy` (5-life) game: 5 circles show, all filled.
- [ ] Lose a life: one circle greys out; the track stays 5 wide.
- [ ] Standard/3-life mode still shows 3 circles.
