### PR TITLE
fix: make game-screen text non-selectable (Closes #67)

### DIFF
--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -407,6 +407,8 @@ export const GamePage = () => {
         position: 'relative',
         overflowX: 'hidden',
         overflowY: 'auto',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
         background: 'linear-gradient(135deg, #1a0533 0%, #0d1b4b 100%)',
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
Adds user-select:none to the gameplay container so text can't be highlighted mid-game.

Closes #67
