### PR TITLE
fix: allow rejoining an in-progress game (Closes #69)

### DIFF
--- a/app/imports/api/rooms.js
+++ b/app/imports/api/rooms.js
@@ -233,7 +233,6 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
 
       const room = await RoomsCollection.findOneAsync({ pin: pin.trim() });
       if (!room) throw new Meteor.Error('not-found', 'Room not found');
-      if (room.status !== 'lobby') throw new Meteor.Error('not-lobby', 'Game already started');
 
       const player = room.players.find((p) => p.id === playerId);
 


### PR DESCRIPTION
rooms.reconnect no longer rejects in_progress games. Combined with the existing lobby-to-/game redirect and players.join dedupe by lobbyPlayerId, a disconnected player can rejoin a running game.

Closes #69
