### PR TITLE
fix: don't replay the sequence on refresh (Closes #68)

### DIFF
--- a/app/imports/ui/ColourSequence.jsx
+++ b/app/imports/ui/ColourSequence.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 const SHAPE_ICONS = {
   red: () => <rect x="18" y="18" width="28" height="28" rx="4" fill="none" stroke="white" strokeWidth="3" />,
@@ -35,14 +35,25 @@ export const ColourSequence = ({
   playerCanInput,
   onColourClick,
   flashingSpeed = 'medium',
+  autoPlay = true,
 }) => {
   const [activeColour, setActiveColour] = useState(null);
   const [clickedColour, setClickedColour] = useState(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isDone, setIsDone] = useState(false);
+  const hasRunRef = useRef(false);
 
   useEffect(() => {
     if (!sequence || sequence.length === 0) return;
+
+    const initialRun = !hasRunRef.current;
+    hasRunRef.current = true;
+    if (initialRun && !autoPlay) {
+      // already watched (refresh): skip replay, go straight to input
+      setIsPlaying(false);
+      setIsDone(true);
+      return;
+    }
 
     let i = 0;
     let cancelled = false;

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -12,6 +12,8 @@ import { EliminationFeed } from '../EliminationFeed.jsx';
 import { useLocation } from 'react-router-dom';
 import { TileLattice } from '../components/design';
 
+const seqSeenKey = (gameId, roundId) => `seqSeen:${gameId}:${roundId}`;
+
 export const GamePage = () => {
   const [playerId, setPlayerId] = useState(null);
   const [playerCanInput, setPlayerCanInput] = useState(false);
@@ -130,13 +132,19 @@ export const GamePage = () => {
   }, [round?._id, playerId, gameId, playerNameFromLobby, lobbyPlayerId, isBattleRoyale, accountId]);
 
   useEffect(() => {
-    setPlayerCanInput(false);
+    if (!player?.roundId) return;
     setAttemptedSequence([]);
     setMessage('');
     setSecondsLeft(30);
     setCompletedRoundId(null);
-    setReplayKey((prev) => prev + 1); // play sequence flash for new round
-  }, [player?.roundId]); // watch sequence of player's specific roundId
+    if (gameId && localStorage.getItem(seqSeenKey(gameId, player.roundId))) {
+      // already watched this round (e.g. refresh): skip the replay
+      setPlayerCanInput(true);
+    } else {
+      setPlayerCanInput(false);
+      setReplayKey((prev) => prev + 1);
+    }
+  }, [player?.roundId, gameId]);
 
   // Show the slow-motion powerup popup whenever the player picks it up
   useEffect(() => {
@@ -540,11 +548,13 @@ export const GamePage = () => {
             roundId={round._id}
             sequence={round.sequence}
             replayKey={replayKey}
+            autoPlay={!(gameId && player?.roundId && localStorage.getItem(seqSeenKey(gameId, player.roundId)))}
             playerCanInput={playerCanInput}
             onSequenceComplete={() => {
               playTurnStartSound();
               setPlayerCanInput(true);
               setMessage('Your turn. Repeat the sequence.');
+              if (gameId && player?.roundId) localStorage.setItem(seqSeenKey(gameId, player.roundId), '1');
             }}
             onColourClick={handleColourClick}
             flashingSpeed={


### PR DESCRIPTION
Gates the sequence replay on a localStorage seen-flag per game+round, so refreshing an already-watched round no longer re-shows the answer. New-round and post-mistake replays are unchanged.

Closes #68
