### PR TITLE
fix: no timer in battle royale (Closes #76)

### DIFF
--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -168,6 +168,7 @@ export const GamePage = () => {
   };
 
   useEffect(() => {
+    if (isBattleRoyale) return undefined; // battle royale is a free-for-all: no timer
     if (!playerCanInput || !playerId) {
       return undefined;
     }
@@ -210,7 +211,7 @@ export const GamePage = () => {
       window.clearTimeout(timeoutId);
       window.clearInterval(intervalId);
     };
-  }, [playerCanInput, playerId, round?._id]);
+  }, [playerCanInput, playerId, round?._id, isBattleRoyale]);
 
   const handleSubmit = () => {
     if (!playerId) {
@@ -577,7 +578,7 @@ export const GamePage = () => {
           >
             {message}
           </p>
-          {playerCanInput && (
+          {!isBattleRoyale && playerCanInput && (
             <p
               style={{
                 color: secondsLeft <= 5 ? '#ff7a7a' : '#9ce8ff',


### PR DESCRIPTION
Battle Royale now skips the turn timer entirely — the effect early-returns and the countdown is hidden — keeping it a free-for-all.

Note: overlaps the timer effect touched by #75 (round timer), so expect a small merge conflict there.

Closes #76
