### PR TITLE
fix: whole-round timer + eliminate on timeout + remove disconnected players (Closes #75)

### DIFF
--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -242,9 +242,13 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
 
     // Add a player to a round
     async 'players.join'(roundId, playerName, gameId = null, lobbyPlayerId = null, isBattleRoyale = false, accountId = null) {
+      const connectionId = this.connection?.id ?? null;
       if (lobbyPlayerId) {
         const existing = await PlayersCollection.findOneAsync({ gameId, lobbyPlayerId });
-        if (existing) return existing._id;
+        if (existing) {
+          await PlayersCollection.updateAsync(existing._id, { $set: { connectionId } });
+          return existing._id;
+        }
       }
 
       const room = await RoomsCollection.findOneAsync({ pin: gameId });
@@ -271,6 +275,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         isBattleRoyale,
         slowMotionActive: false,
         eliminatedAt: null,
+        connectionId,
       });
     },
 
@@ -422,6 +427,35 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
       };
     },
 
+    // Round timer ran out: eliminate the player so the round can advance.
+    async 'players.timeoutRound'(playerId) {
+      const player = await PlayersCollection.findOneAsync(playerId);
+      if (!player || player.eliminated || player.winner || player.gameFinished || player.completeRound) {
+        return { ignored: true };
+      }
+      const round = await RoundsCollection.findOneAsync(player.roundId);
+      const isBattleRoyale = player.isBattleRoyale ?? false;
+      const longestStreak = Math.max(player.longestStreak ?? 0, player.currentStreak ?? 0);
+
+      await PlayersCollection.updateAsync(playerId, {
+        $set: {
+          lives: 0,
+          currentStreak: 0,
+          longestStreak,
+          eliminated: true,
+          eliminatedRound: round ? (round.roundNumber ?? round.lengthOfSequence - 3) : (player.eliminatedRound ?? 0),
+          eliminatedAt: new Date(),
+        },
+      });
+
+      await checkWinner(player.gameId, isBattleRoyale);
+      if (!isBattleRoyale) {
+        const updatedRound = await RoundsCollection.findOneAsync(player.roundId);
+        if (updatedRound) await advanceRoundIfReady(updatedRound);
+      }
+      return { success: true, eliminated: true };
+    },
+
     // advance game to next round
     async 'rounds.advance'(currentRoundId) {
       // get current round
@@ -501,5 +535,31 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
     async 'game.resetSequences'(gameId) {
       await RoundsCollection.removeAsync({ gameId });
     },
+  });
+
+  // Remove a player who disconnects and does not reconnect within the grace
+  // window, so a leaver does not stall the round for everyone else.
+  const DISCONNECT_GRACE_MS = 15000;
+  Meteor.onConnection((connection) => {
+    connection.onClose(() => {
+      const closedId = connection.id;
+      Meteor.setTimeout(async () => {
+        const gone = await PlayersCollection.find({
+          connectionId: closedId,
+          eliminated: false,
+          gameFinished: false,
+        }).fetchAsync();
+        for (const p of gone) {
+          await PlayersCollection.removeAsync(p._id);
+          await LeaderboardCollection.removeAsync({ gameId: p.gameId, playerId: p._id });
+          if (p.lobbyPlayerId) {
+            await RoomsCollection.updateAsync({ pin: p.gameId }, { $pull: { players: { id: p.lobbyPlayerId } } });
+          }
+          await checkWinner(p.gameId, p.isBattleRoyale ?? false);
+          const round = await RoundsCollection.findOneAsync(p.roundId);
+          if (round) await advanceRoundIfReady(round);
+        }
+      }, DISCONNECT_GRACE_MS);
+    });
   });
 }

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -12,13 +12,15 @@ import { EliminationFeed } from '../EliminationFeed.jsx';
 import { useLocation } from 'react-router-dom';
 import { TileLattice } from '../components/design';
 
+const ROUND_SECONDS = 60; // whole-round timer
+
 export const GamePage = () => {
   const [playerId, setPlayerId] = useState(null);
   const [playerCanInput, setPlayerCanInput] = useState(false);
   const [attemptedSequence, setAttemptedSequence] = useState([]);
   const [message, setMessage] = useState('');
   const [levelUpNotices, setLevelUpNotices] = useState([]);
-  const [secondsLeft, setSecondsLeft] = useState(30);
+  const [secondsLeft, setSecondsLeft] = useState(ROUND_SECONDS);
   const [shake, setShake] = useState(false);
   const [correctGlow, setCorrectGlow] = useState(false);
   const [replayKey, setReplayKey] = useState(0);
@@ -168,49 +170,32 @@ export const GamePage = () => {
   };
 
   useEffect(() => {
-    if (!playerCanInput || !playerId) {
-      return undefined;
-    }
+    if (isBattleRoyale) return undefined; // battle royale is a free-for-all: no timer
+    if (!round?._id || !playerId) return undefined;
+    if (player?.eliminated || player?.gameFinished) return undefined;
+    if (completedRoundId === round._id) return undefined; // already finished this round
 
-    setSecondsLeft(30);
+    // One timer for the whole round; wrong guesses and lost lives do not reset it.
+    // If it runs out the player is eliminated so the game can continue.
+    setSecondsLeft(ROUND_SECONDS);
 
     const timeoutId = window.setTimeout(() => {
-      setMessage('Time is up! You lost a life.');
-      Meteor.call('players.timeoutTurn', playerId, (error, result) => {
-        if (error) {
-          console.error(error);
-          setMessage('Something went wrong while handling the timer.');
-          return;
-        }
-
-        if (result?.remainingLives <= 0) {
-          setMessage('Time is up! You have been eliminated!');
-          setPlayerCanInput(false);
-        } else if (typeof result?.remainingLives === 'number') {
-          setMessage(`Time is up! ${result.remainingLives} ${result.remainingLives === 1 ? 'life' : 'lives'} remaining.`);
-          setAttemptedSequence([]);
-          setPlayerCanInput(true);
-          setReplayKey((prev) => prev + 1);
-        }
+      setMessage('Time is up! You have been eliminated.');
+      setPlayerCanInput(false);
+      Meteor.call('players.timeoutRound', playerId, (error) => {
+        if (error) console.error(error);
       });
-    }, 30000);
+    }, ROUND_SECONDS * 1000);
 
     const intervalId = window.setInterval(() => {
-      setSecondsLeft((prev) => {
-        if (prev <= 1) {
-          window.clearInterval(intervalId);
-          return 0;
-        }
-
-        return prev - 1;
-      });
+      setSecondsLeft((prev) => (prev <= 1 ? 0 : prev - 1));
     }, 1000);
 
     return () => {
       window.clearTimeout(timeoutId);
       window.clearInterval(intervalId);
     };
-  }, [playerCanInput, playerId, round?._id]);
+  }, [round?._id, playerId, isBattleRoyale, player?.eliminated, player?.gameFinished, completedRoundId]);
 
   const handleSubmit = () => {
     if (!playerId) {
@@ -577,7 +562,7 @@ export const GamePage = () => {
           >
             {message}
           </p>
-          {playerCanInput && (
+          {!isBattleRoyale && playerCanInput && (
             <p
               style={{
                 color: secondsLeft <= 5 ? '#ff7a7a' : '#9ce8ff',


### PR DESCRIPTION
The timer is now a single 60s budget per round (`ROUND_SECONDS`), not reset by wrong guesses or lost lives. On expiry the player is eliminated (new `players.timeoutRound`) so the round advances. Skipped in Battle Royale (overlaps #76 — expect a small conflict in the timer effect).

Disconnect: `players.join` records the DDP `connectionId`; on connection close a 15s grace timer removes the player from players/leaderboard/room and re-runs winner/advance — unless they reconnected first (a refresh keeps you in via the existing reconnect path).

New surface: `players.timeoutRound` method, `connectionId` field on player docs.

Not yet verified in a live multiplayer game — round-timeout elimination and disconnect removal need manual testing.

Closes #75



Also persists the round-timer start in localStorage so a refresh continues the same countdown instead of restarting it.

Closes #86