### PR TITLE
fix: emit level-up events in battle royale (Closes #81)

### DIFF
--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -333,6 +333,16 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
             },
           });
 
+          // announce the level-up so it shows in the live levels feed
+          await GameEventsCollection.insertAsync({
+            gameId: player.gameId,
+            type: 'level-up',
+            playerId: player._id,
+            playerName: player.name,
+            level: nextLevel - 3,
+            createdAt: new Date(),
+          });
+
           return { success: true, sequenceComplete: true };
         }
 


### PR DESCRIPTION
Battle Royale advances each player directly in `submitSequence` and never emitted a `level-up` GameEvent, so the live levels feed stayed empty in BR. It now emits one per BR advance (`level = nextLevel - 3`, matching the standard path's display).

Pre-existing on `dev` — not caused by #76 (whose diff only touches the timer).

Closes #81
