### PR TITLE
chore: central constants file (Closes #89)

### DIFF
--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -6,9 +6,15 @@ import { PlayerAccountsCollection } from './playerAccounts';
 import { GameEventsCollection } from './gameEvents';
 import { GlobalLeaderboardCollection } from './globalLeaderboard';
 import { RoomsCollection } from './rooms';
-
-const COLOURS = ['red', 'blue', 'green', 'yellow'];
-const GLOBAL_LEADERBOARD_SIZE = 50;
+import {
+  SEQUENCE_COLOURS as COLOURS,
+  GLOBAL_LEADERBOARD_SIZE,
+  DEFAULT_SEQUENCE_LENGTH,
+  DEFAULT_STARTING_LIVES,
+  INITIAL_LEVEL,
+  BONUS_LIFE_ROUND,
+  DISCONNECT_GRACE_MS,
+} from '../constants';
 
 // generate random colour sequence
 function generateSequence(length) {
@@ -230,7 +236,9 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
     // Generate a new round with a colour sequence
     async 'rounds.generate'(gameId = null) {
       const room = await RoomsCollection.findOneAsync({ pin: gameId });
-      const length = room?.customSettings?.startingSequenceLength ? room.customSettings.startingSequenceLength : 4;
+      const length = room?.customSettings?.startingSequenceLength
+        ? room.customSettings.startingSequenceLength
+        : DEFAULT_SEQUENCE_LENGTH;
 
       const sequence = generateSequence(length);
 
@@ -258,7 +266,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
       }
 
       const room = await RoomsCollection.findOneAsync({ pin: gameId });
-      const startingLives = room?.customSettings?.startingLives ? room.customSettings.startingLives : 3;
+      const startingLives = room?.customSettings?.startingLives ? room.customSettings.startingLives : DEFAULT_STARTING_LIVES;
 
       return PlayersCollection.insertAsync({
         gameId,
@@ -272,7 +280,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         longestStreak: 0,
         totalGuesses: 0,
         correctGuesses: 0,
-        currentLevel: 4,
+        currentLevel: INITIAL_LEVEL,
         eliminatedRound: null,
         eliminated: false,
         winner: false,
@@ -302,7 +310,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         const totalGuesses = (player.totalGuesses ?? 0) + 1;
         const correctGuesses = (player.correctGuesses ?? 0) + 1;
 
-        const bonusLife = round.roundNumber === 7 ? 1 : 0;
+        const bonusLife = round.roundNumber === BONUS_LIFE_ROUND ? 1 : 0;
         const lives = (player.lives ?? 0) + bonusLife;
 
         // mark player as completed
@@ -545,7 +553,6 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
 
   // Remove a player who disconnects and does not reconnect within the grace
   // window, so a leaver does not stall the round for everyone else.
-  const DISCONNECT_GRACE_MS = 15000;
   Meteor.onConnection((connection) => {
     connection.onClose(() => {
       const closedId = connection.id;

--- a/app/imports/api/playerAccounts.js
+++ b/app/imports/api/playerAccounts.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { createHash, randomBytes } from 'crypto';
+import { MIN_PASSWORD_LENGTH } from '../constants';
 
 // Guard against --full-app test mode evaluating this module twice
 // (app bundle + test bundle both load it; global is shared across both).
@@ -41,8 +42,8 @@ if (Meteor.isServer && !global._playerAccountsServerInitialized) {
         throw new Meteor.Error('invalid-email', 'Please enter a valid email address.');
       }
 
-      if (password.length < 8) {
-        throw new Meteor.Error('weak-password', 'Password must be at least 8 characters.');
+      if (password.length < MIN_PASSWORD_LENGTH) {
+        throw new Meteor.Error('weak-password', `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
       }
 
       const existingAccount = await PlayerAccountsCollection.findOneAsync({ email });

--- a/app/imports/api/rooms.js
+++ b/app/imports/api/rooms.js
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import { PlayersCollection } from './players.js';
 import { RoundsCollection } from './rounds.js';
+import { PIN_ALPHABET, PIN_LENGTH, GAME_MODE_PRESETS } from '../constants';
 
 // Guard against --full-app test mode evaluating this module twice
 // (app bundle + test bundle both load it; global is shared across both).
@@ -11,17 +12,10 @@ if (!global._RoomsCollection) {
 }
 export const RoomsCollection = global._RoomsCollection;
 
-const PIN_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-const GAME_MODE_PRESETS = {
-  default: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 4 },
-  easy: { flashingSpeed: 'slow', startingLives: 5, startingSequenceLength: 1 },
-  medium: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 3 },
-  hard: { flashingSpeed: 'fast', startingLives: 1, startingSequenceLength: 3 },
-  battle_royale: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 4 },
-};
-
 function generatePin() {
-  return Array.from({ length: 5 }, () => PIN_CHARS[Math.floor(Math.random() * PIN_CHARS.length)]).join('');
+  return Array.from({ length: PIN_LENGTH }, () => PIN_ALPHABET[Math.floor(Math.random() * PIN_ALPHABET.length)]).join(
+    ''
+  );
 }
 
 if (Meteor.isServer && !global._roomsServerInitialized) {
@@ -73,11 +67,7 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
         players: [{ id: hostId, name, accountId: hostAccountId }],
         createdAt: new Date(),
         gameMode: 'default',
-        customSettings: {
-          flashingSpeed: 'medium',
-          startingLives: 3,
-          startingSequenceLength: 4,
-        },
+        customSettings: { ...GAME_MODE_PRESETS.default },
       });
 
       return { pin: pin, hostId: hostId };

--- a/app/imports/constants.js
+++ b/app/imports/constants.js
@@ -1,0 +1,41 @@
+// Central place for tunable game/config constants. Pure module (no imports),
+// safe on client and server. Values are unchanged from where they were inlined.
+
+// --- Gameplay ---
+export const DEFAULT_STARTING_LIVES = 3;
+export const DEFAULT_SEQUENCE_LENGTH = 4;
+export const INITIAL_LEVEL = 4; // starting currentLevel (level 1 == sequence length 4)
+export const BONUS_LIFE_ROUND = 7; // completing this round grants +1 life
+export const ROUND_TIMER_SECONDS = 60; // whole-round countdown (not battle royale)
+export const SEQUENCE_COLOURS = ['red', 'blue', 'green', 'yellow'];
+
+// --- Rooms ---
+export const PIN_LENGTH = 5;
+export const PIN_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+export const DISCONNECT_GRACE_MS = 15000; // remove a disconnected player after this
+
+// Game-mode presets, copied into room.customSettings on selection.
+export const GAME_MODE_PRESETS = {
+  default: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 4 },
+  easy: { flashingSpeed: 'slow', startingLives: 5, startingSequenceLength: 1 },
+  medium: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 3 },
+  hard: { flashingSpeed: 'fast', startingLives: 1, startingSequenceLength: 3 },
+  battle_royale: { flashingSpeed: 'medium', startingLives: 3, startingSequenceLength: 4 },
+};
+
+// Sequence playback speeds, in ms.
+export const FLASH_SPEEDS = {
+  slow: { flash: 900, gap: 350 },
+  medium: { flash: 600, gap: 250 },
+  fast: { flash: 350, gap: 150 },
+};
+
+// --- Accounts ---
+export const MIN_PASSWORD_LENGTH = 8;
+
+// --- Leaderboard ---
+export const GLOBAL_LEADERBOARD_SIZE = 50;
+
+// --- UI durations (ms) ---
+export const ELIMINATION_FEED_MS = 4000;
+export const LEVEL_UP_TOAST_MS = 4000;

--- a/app/imports/ui/ColourSequence.jsx
+++ b/app/imports/ui/ColourSequence.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { FLASH_SPEEDS } from '../constants';
 
 const SHAPE_ICONS = {
   red: () => <rect x="18" y="18" width="28" height="28" rx="4" fill="none" stroke="white" strokeWidth="3" />,
@@ -20,12 +21,6 @@ const COLOURS = {
 };
 
 const TILE_ORDER = ['red', 'yellow', 'green', 'blue'];
-
-const FLASH_SPEEDS = {
-  slow:   { flash: 900, gap: 350 },
-  medium: { flash: 600, gap: 250 },
-  fast:   { flash: 350, gap: 150 },
-};
 
 export const ColourSequence = ({
   roundId,

--- a/app/imports/ui/EliminationFeed.jsx
+++ b/app/imports/ui/EliminationFeed.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { PlayersCollection } from '../api/players';
-
-const DISPLAY_MS = 4000;
+import { ELIMINATION_FEED_MS as DISPLAY_MS } from '../constants';
 
 export const EliminationFeed = ({ gameId }) => {
   const eliminations = useTracker(() => {

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -11,8 +11,8 @@ import { EndLeaderboard } from '../EndLeaderboard.jsx';
 import { EliminationFeed } from '../EliminationFeed.jsx';
 import { useLocation } from 'react-router-dom';
 import { TileLattice } from '../components/design';
+import { ROUND_TIMER_SECONDS as ROUND_SECONDS, LEVEL_UP_TOAST_MS } from '../../constants';
 
-const ROUND_SECONDS = 60; // whole-round timer
 const seqSeenKey = (gameId, roundId) => `seqSeen:${gameId}:${roundId}`;
 
 export const GamePage = () => {
@@ -166,7 +166,7 @@ export const GamePage = () => {
       };
       setLevelUpNotices((prev) => [...prev, notice]);
       // auto-dismiss like the elimination feed
-      setTimeout(() => setLevelUpNotices((prev) => prev.filter((n) => n.key !== notice.key)), 4000);
+      setTimeout(() => setLevelUpNotices((prev) => prev.filter((n) => n.key !== notice.key)), LEVEL_UP_TOAST_MS);
     });
   }, [levelUpEvents]);
 


### PR DESCRIPTION
Adds `app/imports/constants.js` as one place for the tunable game/config values and wires the code to import from it. Pure refactor — values are unchanged.

Centralised: starting lives, sequence length, initial level, bonus-life round, round-timer seconds, sequence colours, PIN length/alphabet, disconnect grace, game-mode presets, flash speeds, min password length, global-leaderboard size, elimination-feed and level-up toast durations.

Wired: `rooms.js`, `gameMethods.js`, `playerAccounts.js`, `ColourSequence.jsx`, `EliminationFeed.jsx`, `GamePage.jsx`.

Notes:
- `imports/api/sequence.js` keeps its own `COLOURS` (it's the unused duplicate the game never calls).
- A few defensive `?? 3` fallbacks are left inline; the definitions are what's centralised.
- Touches files with several open PRs (gameMethods/GamePage/rooms), so expect merge conflicts when those land.
- Not build-tested locally (no Docker here) — worth a `meteor` boot before merge.

Closes #89
