### PR TITLE
feat: connected flag for lobby/in-game disconnects (Closes #91)

### DIFF
--- a/app/imports/api/gameMethods.js
+++ b/app/imports/api/gameMethods.js
@@ -252,7 +252,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
       if (lobbyPlayerId) {
         const existing = await PlayersCollection.findOneAsync({ gameId, lobbyPlayerId });
         if (existing) {
-          await PlayersCollection.updateAsync(existing._id, { $set: { connectionId } });
+          await PlayersCollection.updateAsync(existing._id, { $set: { connectionId, connected: true } });
           return existing._id;
         }
       }
@@ -282,6 +282,7 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
         slowMotionActive: false,
         eliminatedAt: null,
         connectionId,
+        connected: true,
       });
     },
 
@@ -549,9 +550,22 @@ if (Meteor.isServer && !global._gameMethodsInitialized) {
   Meteor.onConnection((connection) => {
     connection.onClose(() => {
       const closedId = connection.id;
+
+      // Flag as disconnected right away. In the lobby the player is kept and
+      // pruned at rooms.start; in game they are grace-removed below unless they
+      // reconnect (which flips connected back to true).
+      (async () => {
+        await RoomsCollection.updateAsync(
+          { status: 'lobby', 'players.connectionId': closedId },
+          { $set: { 'players.$.connected': false } }
+        );
+        await PlayersCollection.updateAsync({ connectionId: closedId }, { $set: { connected: false } });
+      })();
+
       Meteor.setTimeout(async () => {
         const gone = await PlayersCollection.find({
           connectionId: closedId,
+          connected: false,
           eliminated: false,
           gameFinished: false,
         }).fetchAsync();

--- a/app/imports/api/rooms.js
+++ b/app/imports/api/rooms.js
@@ -41,6 +41,7 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
           gameMode: 1,
           'players.name': 1,
           'players.id': 1,
+          'players.connected': 1,
         },
       }
     );
@@ -70,7 +71,7 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
         hostName: name,
         gameName: `Game${pin}`,
         status: 'lobby',
-        players: [{ id: hostId, name, accountId: hostAccountId }],
+        players: [{ id: hostId, name, accountId: hostAccountId, connected: true, connectionId: this.connection?.id ?? null }],
         createdAt: new Date(),
         gameMode: 'default',
         customSettings: {
@@ -137,6 +138,9 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
       if (!room) throw new Meteor.Error('not-found', 'Room not found');
       if (room.status !== 'lobby') throw new Meteor.Error('not-lobby', 'Game already started');
 
+      // Drop anyone who disconnected in the lobby and did not reconnect.
+      await RoomsCollection.updateAsync({ _id: room._id }, { $pull: { players: { connected: false } } });
+
       // Clear old game data so new game starts fresh
       await PlayersCollection.removeAsync({ gameId: pin });
       await RoundsCollection.removeAsync({ gameId: pin });
@@ -195,7 +199,17 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
 
       await RoomsCollection.updateAsync(
         { _id: room._id },
-        { $push: { players: { id: playerId, name: playerName.trim(), accountId: joinAccountId } } }
+        {
+          $push: {
+            players: {
+              id: playerId,
+              name: playerName.trim(),
+              accountId: joinAccountId,
+              connected: true,
+              connectionId: this.connection?.id ?? null,
+            },
+          },
+        }
       );
 
       return { roomId: room.pin, playerId: playerId };
@@ -240,6 +254,11 @@ if (Meteor.isServer && !global._roomsServerInitialized) {
       if (!player) {
         throw new Meteor.Error('player-not-found');
       }
+
+      await RoomsCollection.updateAsync(
+        { pin: pin.trim(), 'players.id': playerId },
+        { $set: { 'players.$.connected': true, 'players.$.connectionId': this.connection?.id ?? null } }
+      );
 
       return {
         playerName: player.name,


### PR DESCRIPTION
Adds a `connected` flag so disconnected players don't break the lobby or the live leaderboard.

- `room.players` entries and player docs now carry `connected` plus a bound `connectionId`.
- On DDP close: lobby players are flagged `connected=false` (kept, can rejoin); in-game players are flagged and removed after the ~15s grace **unless they reconnect** — a refresh survives because reconnecting flips `connected` back to true.
- `rooms.reconnect` (lobby) and `players.join` dedupe (in-game refresh) set `connected=true` and refresh `connectionId`.
- `rooms.start` prunes any `connected=false` players before starting.
- `rooms.lobby` now publishes `players.connected`.

Builds on #80 (in-game grace removal, already on dev). Removing dropped players is what lets the round advance and keeps the live leaderboard correct.

Caveats:
- Not build-tested here (no Docker), and disconnect flows are hard to unit-test — please do a manual multiplayer check.
- Optional follow-ups (not done): grey out `connected=false` players in the lobby UI, and hide them from the live leaderboard during the grace window.

Closes #91
