### PR TITLE
fix: scale the game screen to the viewport so CLEAR and SUBMIT stay visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,7 +443,7 @@ One line each, so a review can cite an ID without opening anything.
 | D12 | `ColourSequence.jsx:80-92` | A new `AudioContext` per tile click, never closed |
 | D14 | repo-wide | `npm run format:check` fails on `main`. Needs one dedicated formatting commit before it can gate CI |
 
-Fixed and kept for history in the register: D1, D2, D9, D10.
+Fixed and kept for history in the register: D1, D2, D9, D10, D15, D16, D17, D18, D19.
 
 ### Not a defect, so nobody chases it again
 

--- a/app/imports/ui/ColourSequence.jsx
+++ b/app/imports/ui/ColourSequence.jsx
@@ -119,16 +119,17 @@ export const ColourSequence = ({
     onColourClick(colourId);
   };
   return (
-    <div>
+    <div style={{ '--tile-grid': 'min(360px, 90vw, 38dvh)' }}>
       <p
         style={{
           color: 'white',
           textAlign: 'center',
-          marginBottom: '16px',
+          marginBottom: 'clamp(8px, 1.6dvh, 16px)',
           fontWeight: 'bold',
           letterSpacing: '2px',
-          minHeight: '24px',
-          fontSize: '0.9rem',
+          minHeight: '1.6em',
+          lineHeight: 1.6,
+          fontSize: 'clamp(0.78rem, 2.6vw, 0.9rem)',
         }}
       >
         {isPlaying && 'WATCH THE SEQUENCE'}
@@ -140,7 +141,7 @@ export const ColourSequence = ({
           display: 'grid',
           gridTemplateColumns: '1fr 1fr',
           gap: '6px',
-          width: 'min(360px, 90vw)',
+          width: 'var(--tile-grid)',
           margin: '0 auto',
         }}
       >
@@ -156,8 +157,8 @@ export const ColourSequence = ({
               disabled={!playerCanInput}
               onClick={() => handleTileClick(colourId)}
               style={{
-                width: 'calc(min(360px, 90vw) / 2 - 3px)',
-                height: 'calc(min(360px, 90vw) / 2 - 3px)',
+                width: 'calc(var(--tile-grid) / 2 - 3px)',
+                height: 'calc(var(--tile-grid) / 2 - 3px)',
                 backgroundColor: bg,
                 display: 'flex',
                 alignItems: 'center',
@@ -173,7 +174,7 @@ export const ColourSequence = ({
                 transform: isActive ? 'scale(0.95)' : 'scale(1)',
               }}
             >
-              <svg width="64" height="64" viewBox="0 0 64 64">
+              <svg width="36%" height="36%" viewBox="0 0 64 64">
                 <ShapeIcon />
               </svg>
             </button>

--- a/app/imports/ui/pages/GamePage.jsx
+++ b/app/imports/ui/pages/GamePage.jsx
@@ -482,7 +482,10 @@ export const GamePage = () => {
           </div>
         ))}
       </div>
-      <div className="relative flex shrink-0 justify-between px-7 py-5" style={{ width: '100%' }}>
+      <div
+        className="relative flex shrink-0 justify-between"
+        style={{ width: '100%', padding: 'clamp(6px, 1.5dvh, 20px) clamp(16px, 2vw, 28px)' }}
+      >
         <span
           style={{
             fontSize: 'clamp(20px, 2vw, 40px)',
@@ -495,20 +498,20 @@ export const GamePage = () => {
           KIMPLY
         </span>
       </div>
-      <div className="relative flex flex-1 flex-col items-center justify-start md:justify-center">
-        <div style={{ display: 'flex', justifyContent: 'flex-start', gap: '1vw', marginBottom: '2vh' }}>
+      <div className="relative flex min-h-0 flex-1 flex-col items-center justify-start overflow-y-auto md:justify-center">
+        <div style={{ display: 'flex', justifyContent: 'flex-start', gap: '1vw', marginBottom: '2dvh' }}>
           {Array.from({ length: totalLives }, (_, i) => i + 1).map((heart) => (
             <div
               key={heart}
               style={{
-                width: 'clamp(60px, 8vw, 80px)',
-                height: 'clamp(60px, 8vw, 80px)',
+                width: 'clamp(26px, 6dvh, 76px)',
+                height: 'clamp(26px, 6dvh, 76px)',
                 backgroundColor: heart <= (player?.lives ?? totalLives) ? '#e03030' : '#333',
                 borderRadius: '50%',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                fontSize: 'clamp(30px, 4vw, 32px)',
+                fontSize: 'clamp(14px, 3.2dvh, 32px)',
                 boxShadow: heart <= (player?.lives ?? totalLives) ? '0 0 10px #e0303088' : 'none',
                 transition: 'all 0.3s ease',
               }}
@@ -521,7 +524,7 @@ export const GamePage = () => {
           <p
             style={{
               color: 'white',
-              marginBottom: '1vh',
+              marginBottom: '1dvh',
               fontWeight: 'bold',
               letterSpacing: '2px',
               fontSize: 'clamp(16px, 1.2vw, 22px)',
@@ -534,7 +537,7 @@ export const GamePage = () => {
               display: 'flex',
               justifyContent: 'center',
               gap: '0.5vw',
-              marginBottom: '2vh',
+              marginBottom: '2dvh',
             }}
           >
             {(round.sequence || []).map((_, i) => (
@@ -573,8 +576,9 @@ export const GamePage = () => {
           <p
             style={{
               color: 'white',
-              marginTop: '1.5vh',
-              minHeight: '2vh',
+              marginTop: '1.5dvh',
+              minHeight: '1.25em',
+              lineHeight: 1.25,
               fontSize: 'clamp(12px, 1.2vw, 24px)',
             }}
           >
@@ -583,25 +587,27 @@ export const GamePage = () => {
           <p
             style={{
               color: '#ffd369',
-              marginTop: '0.8vh',
-              minHeight: '2vh',
+              marginTop: '0.8dvh',
+              minHeight: '1.25em',
+              lineHeight: 1.25,
               fontSize: 'clamp(12px, 1.2vw, 20px)',
             }}
           >
             {message}
           </p>
-          {!isBattleRoyale && playerCanInput && (
+          {!isBattleRoyale && (
             <p
               style={{
                 color: secondsLeft <= 5 ? '#ff7a7a' : '#9ce8ff',
-                marginTop: '0.8vh',
-                minHeight: '2vh',
-                fontSize: '1vw',
+                marginTop: '0.8dvh',
+                minHeight: '1.25em',
+                lineHeight: 1.25,
+                fontSize: 'clamp(12px, 1.2vw, 20px)',
                 fontWeight: 'bold',
                 letterSpacing: '1px',
               }}
             >
-              Time left: {secondsLeft}s
+              {playerCanInput ? `Time left: ${secondsLeft}s` : ''}
             </p>
           )}
           <div
@@ -609,7 +615,7 @@ export const GamePage = () => {
               display: 'flex',
               justifyContent: 'center',
               gap: '1vw',
-              marginTop: '2vh',
+              marginTop: '2dvh',
             }}
           >
             <button
@@ -617,7 +623,7 @@ export const GamePage = () => {
               disabled={!playerCanInput || attemptedSequence.length === 0}
               style={{
                 width: 'clamp(100px, 8vw, 300px)',
-                height: 'clamp(40px, 3vw, 200px)',
+                height: 'clamp(34px, 5.5dvh, 60px)',
                 backgroundColor: playerCanInput && attemptedSequence.length > 0 ? '#444' : '#222',
                 color: playerCanInput && attemptedSequence.length > 0 ? 'white' : '#555',
                 fontWeight: 'bold',
@@ -635,7 +641,7 @@ export const GamePage = () => {
               disabled={!playerCanInput || attemptedSequence.length !== round.sequence.length}
               style={{
                 width: 'clamp(100px, 8vw, 300px)',
-                height: 'clamp(40px, 3vw, 200px)',
+                height: 'clamp(34px, 5.5dvh, 60px)',
                 backgroundColor:
                   playerCanInput && attemptedSequence.length === round.sequence.length ? '#666' : '#2a2a3a',
                 color: playerCanInput && attemptedSequence.length === round.sequence.length ? 'white' : '#444',

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -20,6 +20,21 @@ This file is the source of truth for **why** any of that is the way it is.
 
 ---
 
+## 2026-09-01 - The game screen now scales to the viewport instead of overflowing it (D19)
+
+The play column was sized in fixed pixels and `vw`, so it stayed about 740px tall on every screen while the container was pinned to `100dvh` with `overflow: hidden`. Starting the turn added two rows (the message and the `Time left` line, which only existed while input was open), pushed the button row past the fold, and the buttons were clipped with no way to scroll to them. On a full-height 1512x828 laptop there were 7px to spare before the turn started, which is why it read as a mobile bug.
+
+Hearts, the tile grid, the button row and the header padding now scale with `dvh`, the column's rhythm moved from `vh` to `dvh` so it matches the container's own `100dvh`, and the timer row is always rendered so the buttons do not move when the sequence ends.
+
+Two things that are not obvious from the diff:
+
+- **The scroll fallback had to move off the container.** Putting `overflow-y: auto` on the container looked right and was wrong: `TileLattice` is deliberately larger than the screen (1100px tall, offset above the fold), so the container became scrollable by 188px of pure decoration - D18's empty-strip symptom arriving by another route. The container keeps `overflow: hidden` and the fallback sits on the play column, which contains only real content.
+- **`dvh` is what makes this hold on mobile.** The column's margins were `vh`, which on mobile resolves to the largest viewport (toolbar hidden) while the container is `100dvh` (toolbar shown). The column was therefore budgeting against a taller box than it actually had.
+
+Files: `app/imports/ui/pages/GamePage.jsx`, `app/imports/ui/ColourSequence.jsx`, `docs/defect-register.md` (D19), `AGENTS.md`.
+
+Verified end to end in Chrome at 13 viewports from 320x568 to 1920x1080, and in a real 420x583 window: the button row is fully visible in both the watching and the input phase, at the same position in each, and nothing scrolls.
+
 ## 2026-08-31 - Game page uses 100dvh so it stops scrolling into empty space (D18)
 
 The gameplay container used `minHeight: 100vh`. On mobile `100vh` is the largest viewport (address bar hidden), so the container was taller than the visible screen and left an empty strip to scroll into. Switched it to `100dvh`, which tracks the visible area as browser chrome shows/hides. `overflowY: 'auto'` stays, so genuine overflow on short screens still scrolls.

--- a/docs/defect-register.md
+++ b/docs/defect-register.md
@@ -249,6 +249,32 @@ The cost of leaving it is that every branch inherits the dirt, so no diff can be
 
 ---
 
+## D19 - The play column is taller than the screen, so CLEAR and SUBMIT vanish when the turn starts - **fixed 2026-09-01**
+
+The game screen was sized almost entirely in fixed pixels and `vw`: hearts `clamp(60px, 8vw, 80px)`, the tile grid `min(360px, 90vw)`, the button row `clamp(40px, 3vw, 200px)`.
+None of that reacts to how much vertical room there actually is, so the column came out around 740px tall no matter the screen, inside a container fixed at `height: 100dvh` with `overflow: hidden`.
+
+It only tipped over **after the sequence finished playing**, because starting the turn added two more lines to the column - the "Your turn. Repeat the sequence." message and the `Time left: Ns` row, which was rendered only while `playerCanInput` was true.
+The button row is last, so the buttons were what got clipped, and with `overflow: hidden` there was nothing to scroll to reach them.
+
+Measured on a 1512x828 laptop viewport (Medium mode, 3 lives), before the fix:
+
+| Phase | SUBMIT bottom | Viewport |
+|---|---|---|
+| Watching the sequence | 801px | 828px |
+| Your turn | 821px | 828px |
+
+Seven pixels of headroom on a full-height laptop, so any shorter viewport - a phone, or a laptop with a bookmarks bar - lost the buttons outright.
+
+**Fix (applied):** size the column against the viewport height instead of a pixel floor, and stop the layout moving when the turn starts.
+
+- The tile grid, the largest block on the screen, is `min(360px, 90vw, 38dvh)`. It answers to height as well as width, and still caps at its original 360px once there is room.
+- Hearts (`clamp(26px, 6dvh, 76px)`), the button row (`clamp(34px, 5.5dvh, 60px)`) and the header padding (`clamp(6px, 1.5dvh, 20px)`) scale the same way. The column's vertical rhythm moved from `vh` to `dvh`, so it is measured against the same box as the container's `100dvh`.
+- The timer row is always rendered when the mode has a timer, and carries its text only once input opens, so the button row no longer moves when the sequence ends. Its font was `1vw`, about 4px on a phone; it is now `clamp(12px, 1.2vw, 20px)`.
+- `overflow: hidden` stays on the container, because `TileLattice` is deliberately larger than the screen and would otherwise make the page scrollable by its overflow alone (which is D18's symptom returning by another route). The scroll fallback moved onto the play column itself, which holds only real content.
+
+Verified across 13 viewports from 320x568 to 1920x1080: the button row is fully visible at every one, in both phases, with nothing needing to scroll. `app/imports/ui/pages/GamePage.jsx`, `app/imports/ui/ColourSequence.jsx`.
+
 ## D18 - Game page scrolls into empty space below the play area - **fixed 2026-08-31**
 
 The gameplay container in `GamePage` used `minHeight: '100vh'` with `overflowY: 'auto'`. On mobile browsers `100vh` resolves to the largest viewport height (as if the toolbar were hidden), so the container was taller than the visible area and left a strip of empty space the user could scroll into.


### PR DESCRIPTION
## Summary

- The play column was sized in fixed pixels and `vw`, so it stayed roughly 740px tall on every screen, inside a container pinned to `height: 100dvh` with `overflow: hidden`. Starting the turn added two more rows (the message, and the `Time left` row that only existed while input was open), pushed the button row past the fold, and clipped it with nothing to scroll to.
- A full-height 1512x828 laptop had **7px** of headroom before the turn started, which is why this read as a mobile bug. Anything shorter - a phone, or a laptop with a bookmarks bar - lost CLEAR and SUBMIT outright.

What changed:

- The tile grid, the tallest block on the screen, is now `min(360px, 90vw, 38dvh)`: it answers to height as well as width, and still caps at its original 360px once there is room.
- Hearts, the button row and the header padding scale with `dvh` too, and the column's vertical rhythm moved from `vh` to `dvh` so it is measured against the same box as the container's own `100dvh` (on mobile `vh` is the toolbar-hidden height, so the column was budgeting against a taller box than it had).
- The timer row is always rendered when the mode has a timer and carries its text only once input opens, so the button row no longer moves when the sequence finishes. Its font was `1vw`, about 4px on a phone; it is now `clamp(12px, 1.2vw, 20px)`.
- The scroll fallback moved off the container and onto the play column. `TileLattice` is deliberately larger than the screen, so `overflow-y: auto` on the container made the page scrollable by 188px of pure decoration - which is D18's empty-strip symptom arriving by another route.

Recorded as D19 in `docs/defect-register.md`, with a `docs/decision-log.md` entry.

Closes #97

## Test plan

Measured in Chrome, in both the watching and the input phase, on a Medium-mode game:

- [x] SUBMIT fully visible at 320x568, 360x640, 375x600, 390x670, 414x896, 768x1024, 1024x500, 1180x620, 1280x600, 1366x650, 1440x723, 1512x828, 1920x1080
- [x] Nothing scrolls at any of those sizes (the play column's `scrollHeight` equals its `clientHeight`)
- [x] The button row sits at the same position before and after the sequence finishes (SUBMIT bottom 564px in both phases at 1280x600)
- [x] Played through in a real 420x583 window and a real 1512x772 window: the whole board, both status lines and both buttons are on screen