### PR TITLE
Milestone 3: README and Quality Assurance Plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Everything below has a home of its own. Read the home file rather than expecting
 |---|---|
 | [`docs/design_system.md`](docs/design_system.md) | Colour, type, spacing, radii, motion, components, patterns, voice. The design source of truth |
 | [`docs/defect-register.md`](docs/defect-register.md) | Every known defect: how it actually fails and what the fix is |
+| [`docs/quality-assurance-plan-submission.md`](docs/quality-assurance-plan-submission.md) | How quality is defined and enforced: testing plan, git gates, NFRs with measurements, accessibility posture |
 | [`docs/decision-log.md`](docs/decision-log.md) | Dated record of what changed and why, newest first |
 | [`docs/deployment-manual.md`](docs/deployment-manual.md) | Production runbook, from empty AWS account to serving traffic |
 | [`docs/dev-environment.md`](docs/dev-environment.md) | How the development stack differs from production |

--- a/README.md
+++ b/README.md
@@ -1,227 +1,232 @@
 # Kimply
 
-A real-time multiplayer color-sequence memory game (like Simon Says). Players join a room via PIN, wait in a lobby, then compete through color sequences.
+A real-time multiplayer colour-sequence memory game, like Simon Says.
+Players join a room with a 5-character PIN, wait in a lobby, then compete through progressively longer colour sequences until one player is left.
 
-**Team members:**
+No account is needed to play. Accounts exist only so a player can keep a history.
 
-| Name | Email |
-|---|---|
-| Dhruv Israni | dhruv.isr14@gmail.com |
-| Jeremy Lim | jeremylim.0304@gmail.com |
-| Owen Kolotsos | owenkolotsos@outlook.com |
-| Ojaswi Pandey | ojaswioj98@gmail.com |
-| Koby Crosby | crosbk01@gmail.com |
-| Tan Ee Dhing | joycetan613@gmail.com |
-| Trisha Bhagat | trisha.bhagat445@gmail.com |
-| Layela Moyo | layelaheart@gmail.com |
-| Ian Nguyen | mriannguyen352@gmail.com |
-| Zeji Li | jarrodlizeji@gmail.com |
-| Ze Xiang Li | lijefferson73@gmail.com |
-| Benjamin Quan | scientistquan@gmail.com |
-| Lachlan Shi | lshi0046@student.monash.edu |
-| Ambrris Bushen | ambrrisb2803@gmail.com |
+Live: [kimply.online](https://kimply.online) (production, `main`) and [dev.kimply.online](https://dev.kimply.online) (development, `dev`).
+
+|                   |                                                        |
+| ----------------- | ------------------------------------------------------ |
+| Framework         | Meteor 3.4 (bundling, methods, reactive data over DDP) |
+| UI                | React 18, React Router v7, Tailwind CSS 3              |
+| Database          | MongoDB 7.0                                            |
+| Bundler           | Rspack                                                 |
+| Local environment | Docker Compose                                         |
+| Hosting           | AWS EC2 (arm64) behind Nginx, MongoDB Atlas            |
 
 ---
 
-## What you need before starting
+## 1. What you need
 
-- **Git** — to download the code. Check if you have it by running `git --version` in a terminal. If not, download it from [git-scm.com](https://git-scm.com/downloads).
-- **Docker Desktop** — to run the app. Download it from [docker.com/get-started](https://www.docker.com/get-started/).
-- **VS Code** (recommended) — download from [code.visualstudio.com](https://code.visualstudio.com/).
+**Hardware.** Any machine from roughly the last five years.
+Give Docker at least 4 GB of RAM (8 GB total on the machine is comfortable) and keep about 10 GB of free disk.
+The Meteor build is the heavy part, not the game itself.
 
-> **Windows users — stop here and read the WSL2 section below before doing anything else.** Running Docker from PowerShell will break hot reload. This is a known Windows limitation, not a bug.
+**Software.**
 
----
+|                       | Why                                                                   | Get it                                                  |
+| --------------------- | --------------------------------------------------------------------- | ------------------------------------------------------- |
+| Git                   | Clone the repo                                                        | [git-scm.com](https://git-scm.com/downloads)            |
+| Docker Desktop        | Runs everything. You do not install Meteor, Node, or MongoDB yourself | [docker.com](https://www.docker.com/get-started/)       |
+| VS Code (recommended) | Editor. Workspace settings are committed                              | [code.visualstudio.com](https://code.visualstudio.com/) |
+| WSL2 (Windows only)   | See below. Not optional                                               | Section 2                                               |
 
-## Windows Setup (WSL2)
-
-WSL2 (Windows Subsystem for Linux) gives you a real Linux terminal inside Windows. You need to run everything from inside WSL2 so that file changes you make are detected by the app instantly.
-
-### Step 1 — Install WSL2
-
-Open **PowerShell as Administrator** (right-click the Start menu → "Windows PowerShell (Admin)") and run:
-
-```powershell
-wsl --install
-```
-
-This installs WSL2 and Ubuntu automatically. **Restart your computer** when it finishes.
-
-After restarting, Ubuntu will open and ask you to create a Linux username and password. Choose anything — this is just for your local Linux environment.
-
-> Already have WSL? Run `wsl --status` in PowerShell. You should see `Default Version: 2`. If not, run `wsl --set-default-version 2`.
-
-### Step 2 — Configure Docker Desktop
-
-Open Docker Desktop, go to **Settings → Resources → WSL Integration**, and make sure:
-- "Enable integration with my default WSL distro" is **turned on**
-- Ubuntu (or your distro) is **toggled on**
-
-Click **Apply & Restart**.
-
-### Step 3 — Open an Ubuntu terminal
-
-Click the Start menu and search for **Ubuntu**. Open it. You'll see a prompt like:
-
-```
-yourusername@DESKTOP-XXXXX:~$
-```
-
-**All commands from this point forward go into this Ubuntu terminal — not PowerShell.**
-
-### Step 4 — Clone the repo inside WSL2
-
-```bash
-cd ~
-git clone https://github.com/Monash-FIT3170/2026W1-Kimply
-cd 2026W1-Kimply
-```
-
-> **Important:** the project must live inside the WSL2 filesystem (`~/...`), not your Windows drive (`/mnt/c/...`). If you clone into `/mnt/c/Users/...` file watching will not work.
-
-### Step 5 — Open in VS Code
-
-In your Ubuntu terminal run:
-
-```bash
-code .
-```
-
-The first time, VS Code automatically installs the **WSL extension** and reopens the project connected to WSL2. You'll see **WSL: Ubuntu** in the bottom-left corner. All edits you make in VS Code will now live inside WSL2.
+You do **not** need a Meteor, Node, or MongoDB install on your machine.
+Everything runs inside containers.
 
 ---
 
-## Mac / Linux Setup
+## 2. Windows: set up WSL2 first
 
-No special setup needed. Open a terminal, then clone the repo:
+Docker on Windows must be driven from WSL2, and the repo must live inside the WSL2 filesystem.
+Running from PowerShell, or cloning onto your Windows drive at `/mnt/c/...`, breaks file watching so hot reload silently stops working.
+This is a Windows/Docker limitation, not a bug in the project.
+
+1. In **PowerShell as Administrator**, run `wsl --install`, then restart.
+   Ubuntu opens and asks for a Linux username and password. Pick anything.
+   Already have WSL? `wsl --status` must report `Default Version: 2`.
+2. In Docker Desktop, go to **Settings > Resources > WSL Integration**.
+   Enable integration with your default distro, toggle Ubuntu on, then **Apply & Restart**.
+3. Open the **Ubuntu** app from the Start menu.
+   Every command in this README goes in that terminal, never PowerShell.
+
+Mac and Linux need none of this. Just open a terminal.
+
+---
+
+## 3. Get it running
 
 ```bash
 git clone https://github.com/Monash-FIT3170/2026W1-Kimply
 cd 2026W1-Kimply
-```
-
----
-
-## Running the App
-
-Make sure **Docker Desktop is open and running** before continuing.
-
-In your terminal (Ubuntu terminal on Windows), navigate to the project:
-
-```bash
-cd ~/2026W1-Kimply   # Windows/WSL2
-# or
-cd 2026W1-Kimply     # Mac/Linux (wherever you cloned it)
-```
-
-Start the app:
-
-```bash
 docker compose up
 ```
 
-This starts MongoDB and the Meteor dev server. Logs will stream to your terminal. Once you see:
+On Windows, clone into your Linux home (`cd ~` first), not `/mnt/c/...`.
 
-```
-App running at: http://localhost:3000
-```
+With Docker Desktop running, `docker compose up` starts MongoDB and the Meteor dev server.
+Wait for `App running at: http://localhost:3000`, then open <http://localhost:3000>.
 
-open your browser and go to **http://localhost:3000**.
+**The first start takes 5 to 15 minutes** while Meteor downloads packages and compiles from scratch.
+Later starts are much faster because the build is cached in a Docker volume.
 
-> **The first startup takes 5–15 minutes.** Meteor downloads packages and compiles the app from scratch. Subsequent starts are much faster because the build is cached.
+Open VS Code on the project with `code .` from the same terminal.
+On Windows this installs the WSL extension and reopens the project connected to WSL2, shown as **WSL: Ubuntu** in the bottom-left.
+Saving a file hot-reloads the browser.
 
-### Making changes
-
-Edit files in VS Code. Saving a file instantly triggers Meteor's hot reload — the browser updates automatically without you needing to refresh.
-
-### Running in the background
-
-```bash
-docker compose up -d
-```
-
-The `-d` flag runs containers in the background so your terminal stays free. To view logs afterwards:
+Three commands cover day-to-day work.
+Everything else is ordinary Docker Compose, and `docker compose --help` is a better reference than this file.
 
 ```bash
-docker compose logs -f           # all services
-docker compose logs -f backend   # just the Meteor app
-docker compose logs -f mongodb   # just MongoDB
+docker compose up                                  # start MongoDB and the app on :3000
+docker compose exec backend meteor npm test        # run the test suite once
+docker compose exec backend meteor npm run format  # Prettier, the only style gate
 ```
 
-### Stopping
+Install npm packages **inside the container** so they land in the container's `node_modules`, and do not rebuild the image afterwards:
 
 ```bash
-docker compose down
-```
-
-Stops and removes containers but **preserves your data** — MongoDB data lives in a Docker volume and survives restarts.
-
-### Rebuilding the image
-
-Only needed if you change `Dockerfile.dev` or `entrypoint.sh`:
-
-```bash
-docker compose up --build
+docker compose exec backend meteor npm install <package>
 ```
 
 ---
 
-## Other Useful Commands
+## 4. How the code is laid out
 
-```bash
-docker ps                         # check which containers are running
-docker compose restart backend    # restart just the Meteor app
-docker compose down -v            # stop everything AND wipe the database
+Everything Meteor runs lives in `app/`.
+
+```
+app/
+├── client/main.jsx     all client routes
+├── server/             startup, publications, indexes, health
+├── imports/api/        collections and Meteor methods (the whole game loop)
+├── imports/ui/         pages, components, the design system
+└── tests/              meteortesting:mocha specs
+docs/                   design system, defect register, decision log, deployment
+deploy/ nginx/          production infrastructure, environment-agnostic
+.agents/skills/         per-task instructions for coding agents
 ```
 
-### Adding an npm package
-
-Run this inside the container — do not run `npm install` directly:
-
-```bash
-docker compose exec backend meteor npm install <package-name>
-```
-
-You don't need to rebuild the image after adding a package.
-
-## Formatting
-
-This project uses Prettier for code formatting. VS Code workspace settings are committed in `.vscode/` so installing the recommended Prettier extension enables format-on-save.
-
-```bash
-npm run format:check
-npm run format
-```
-
-These commands work from the repository root and forward to the Meteor app in `app/`. If you are already inside `app/`, the same commands work there too.
-
-If you edit through VS Code attached to the Docker container, install the extensions into that attached container:
-
-1. Start the app with `docker compose up`.
-2. In VS Code, run `Dev Containers: Attach to Running Container...`.
-3. Pick the Kimply `backend` container.
-4. Open `/kimply`.
-5. In the Extensions panel, install `Prettier - Code formatter` in the attached container.
-
-The tracked `.vscode/extensions.json` file recommends that extension, and `.vscode/settings.json` handles format-on-save.
+`AGENTS.md` in the repo root is the real map: every collection, publication, method, route, test, and known defect in one table.
+**Read it before reading `imports/api/`.**
+`CLAUDE.md` is a symlink to it, and `.claude/skills` and `.cursor/skills` are symlinks to `.agents/skills`, so every tool sees one set of instructions.
 
 ---
 
-## Troubleshooting
+## 5. Conventions
 
-**The app can't connect to MongoDB**
-Make sure you don't have a local MongoDB instance already running on port 27017. Stop it or change its port.
+These are the rules that are not obvious from the code, and the ones most likely to be broken by accident.
 
-**File changes aren't triggering a reload (Windows)**
-You're probably running Docker from PowerShell or the project is cloned onto your Windows drive (`/mnt/c/...`). Follow the WSL2 setup above and clone into `~/` inside WSL2.
+**Branches and pull requests.**
+`main` is production and `dev` is the integration branch.
+Never push to either.
+Every branch starts from a GitHub issue and is cut with `gh issue develop <n> --name <prefix>/<n>-<slug> --base dev --checkout`, so the branch appears in the issue's Development sidebar.
+Prefixes are `feature/`, `fix/`, `bug/`, `chore/`.
+Every PR targets `dev` and its body contains `Closes #<n>` as its own paragraph.
+The full workflow is `.agents/skills/git/SKILL.md`.
 
-**`docker compose` command not found**
-Make sure Docker Desktop is installed and running. On older Docker versions the command may be `docker-compose` (with a hyphen).
+**Anonymous play is deliberate.**
+The game has no login wall and must not gain one.
+`this.userId` is empty on purpose; do not "fix" it by adding authentication.
 
-**Port 3000 is already in use**
-Another app is using port 3000. Stop that app, or run `docker compose down` first to clean up any leftover containers.
+**All writes go through Meteor methods.**
+`autopublish` and `insecure` are not installed and there are no `.allow()` or `.deny()` rules.
+Adding any of them is a regression.
 
+**Publications are scoped and projected, and that is load-bearing.**
+Rounds publish only `isCurrent: true`, players exclude `attemptedSequence` (it holds the answer a player submitted), and every publication is scoped by `gameId`.
+Removing any of those three leaks the correct sequence or fans DDP traffic out across the whole deployment.
+
+**Only the scripts that exist.**
+`format`, `format:check`, `test`, `test-app` from the repo root or from `app/`.
+There is no `lint`, `build`, `dev`, `typecheck`, or `e2e`, and CI must not invent one.
+Prettier is the only style gate; there is no ESLint.
+
+**One local compose file.**
+`docker-compose.yml` is development only and must keep working.
+Production-shaped changes belong in `docker-compose.prod.yml`.
+`deploy/`, `nginx/`, and `scripts/` are environment-agnostic and read their configuration from `/opt/kimply/.env` on the instance, so do not fork them per environment.
+
+**Docs are part of the change, not a follow-up.**
+Change a collection, publication, method, route, or test, and update the matching table in `AGENTS.md` plus a dated entry at the top of `docs/decision-log.md` in the same commit.
+Fix or introduce a defect, and update `docs/defect-register.md`.
+Design decisions go in `docs/design_system.md`, not in `AGENTS.md`.
+New agent skills go only in `.agents/skills/<name>/SKILL.md`; never copy them into `.claude/` or `.cursor/`.
+
+**CI and deployment.**
+Tests run on pull requests to `main` and `dev`.
+Pushing to `dev` deploys dev.kimply.online, pushing to `main` deploys production, both through `.github/workflows/deploy.yml`, which picks its target from the branch name.
+The two stacks share no AWS resource.
+
+---
+
+## 6. Where to read next
+
+| Document                                                 | Holds                                                                      |
+| -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`AGENTS.md`](AGENTS.md)                                 | Inventory of collections, publications, methods, routes, identity, defects |
+| [`docs/design_system.md`](docs/design_system.md)         | Colour, type, spacing, motion, components, voice                           |
+| [`docs/defect-register.md`](docs/defect-register.md)     | Every known defect, how it fails, and the fix                              |
+| [`docs/decision-log.md`](docs/decision-log.md)           | What changed and why, newest first                                         |
+| [`docs/deployment-manual.md`](docs/deployment-manual.md) | Production runbook, from an empty AWS account to serving traffic           |
+| [`docs/dev-environment.md`](docs/dev-environment.md)     | How the dev stack differs from production                                  |
+| [`docs/operations.md`](docs/operations.md)               | Monitoring, backups, incidents, cost                                       |
+
+---
+
+## 7. Common problems
+
+**File changes do not reload (Windows).**
+You are running from PowerShell, or the repo is on `/mnt/c/...`.
+Clone into `~/` inside WSL2 and run from the Ubuntu terminal.
+
+**The app cannot connect to MongoDB.**
+Something else already holds port 27017, usually a MongoDB installed directly on your machine. Stop it.
+
+**Port 3000 is in use.**
+Run `docker compose down` to clear leftover containers, or stop whatever else is on 3000.
+
+**`docker compose` not found.**
+Docker Desktop is not running or not installed. Very old versions use `docker-compose` with a hyphen.
+
+**The first build seems stuck.**
+It is not. Give it 15 minutes. Meteor is compiling from scratch and prints little while it does.
+
+**`npm ci` fails at the repo root.**
+Known defect D11: the root `package-lock.json` is desynced against an empty root `package.json`.
+Run npm commands against `app/`, or through the container.
+
+**A stray empty overlay appears under the username field on `/play`.**
+That is a browser extension, most likely a password manager, appended outside `#react-target`.
+It is not app markup. Nobody needs to chase it.
+
+**Reset the database.**
+`docker compose down -v` stops everything and wipes the Mongo volume.
+Plain `docker compose down` keeps your data.
+
+---
+
+## Team
+
+| Name           | Email                       |
+| -------------- | --------------------------- |
+| Dhruv Israni   | dhruv.isr14@gmail.com       |
+| Jeremy Lim     | jeremylim.0304@gmail.com    |
+| Owen Kolotsos  | owenkolotsos@outlook.com    |
+| Ojaswi Pandey  | ojaswioj98@gmail.com        |
+| Koby Crosby    | crosbk01@gmail.com          |
+| Tan Ee Dhing   | joycetan613@gmail.com       |
+| Trisha Bhagat  | trisha.bhagat445@gmail.com  |
+| Layela Moyo    | layelaheart@gmail.com       |
+| Ian Nguyen     | mriannguyen352@gmail.com    |
+| Zeji Li        | jarrodlizeji@gmail.com      |
+| Ze Xiang Li    | lijefferson73@gmail.com     |
+| Benjamin Quan  | scientistquan@gmail.com     |
+| Lachlan Shi    | lshi0046@student.monash.edu |
+| Ambrris Bushen | ambrrisb2803@gmail.com      |
 
 ## Licence
-See the LICENSE file in the root of the Repository for the project's MIT license.
-s
+
+MIT. See [`app/LICENSE`](app/LICENSE).

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -20,6 +20,25 @@ This file is the source of truth for **why** any of that is the way it is.
 
 ---
 
+## 2026-09-04 - The Quality Assurance Plan is now a document in the repo
+
+The QA plan existed only as a submission document, written before most of the machinery it described was built.
+It claimed an agile-subteam branch model the repo no longer uses, quoted performance targets that had never been measured, and described security in terms the defect register contradicts.
+
+It now lives at `docs/quality-assurance-plan-submission.md`, and every claim in it is either sourced from the codebase or marked as an unmet target.
+
+Three things that are not obvious from the diff:
+
+- **Unmet requirements are stated as unmet, with the measurement.**
+  The "under 0.5s response" performance NFR is marked not met and carries the real numbers from the load test runs: the sequence submission method at a median of roughly 1.1s locally and 4.4s against dev at 100 players.
+  The plan is more useful as an accurate account of where we are than as a list of things we would like to be true.
+- **The security section is written against the defect register rather than around it.**
+  The outstanding identity and hashing defects appear in the plan with the explicit statement that the fix for the first is connection binding and not a login wall, so a future reader cannot use the QA plan as justification for auth-gating the game.
+- **The plan ends with its own gap list.**
+  It names what it does not yet cover, including the coverage smoke gate, the formatting gate that cannot yet run in CI, and the absent end-to-end test, so the next milestone closes them deliberately instead of rediscovering them.
+
+Files: `docs/quality-assurance-plan-submission.md` (new), `AGENTS.md`.
+
 ## 2026-09-01 - The game screen now scales to the viewport instead of overflowing it (D19)
 
 The play column was sized in fixed pixels and `vw`, so it stayed about 740px tall on every screen while the container was pinned to `100dvh` with `overflow: hidden`. Starting the turn added two rows (the message and the `Time left` line, which only existed while input was open), pushed the button row past the fold, and the buttons were clipped with no way to scroll to them. On a full-height 1512x828 laptop there were 7px to spare before the turn started, which is why it read as a mobile bug.

--- a/docs/quality-assurance-plan-submission.md
+++ b/docs/quality-assurance-plan-submission.md
@@ -1,0 +1,383 @@
+# Quality Assurance Plan
+
+## Definition of Quality Assurance
+
+Quality assurance is the systematic prevention of defects, rather than their detection after the fact.
+It covers the practices that keep a product meeting its requirements while it is still being built, so that issues are identified and removed early rather than accumulating into the final release.
+
+For Kimply, quality assurance is not a phase applied at the end of development.
+It is a continuous practice embedded in every sprint.
+Developers write tests alongside the code they produce, an automated pipeline validates every pull request, and every merge boundary acts as a review gate.
+The goal is that the shared integration branch is in a working and testable state at any point during development, and that a regression is caught at the pull request rather than discovered during a demonstration.
+
+Three practices make this enforceable rather than aspirational.
+
+First, the state of the system is written down where the next developer will look for it.
+The repository carries a shared guidance document that lists every collection, publication, method, and route, a defect register that records every known defect, and a decision log that records why the system is the way it is.
+A change that alters behaviour updates the matching document in the same commit.
+A change that does not do so is treated as incomplete and is rejected at review on that basis.
+
+Second, defects are recorded rather than silently carried.
+A defect the team decides not to fix immediately receives an identifier in the defect register, together with a description of how it actually fails and what the fix would be.
+Deferral therefore becomes an explicit, reviewable decision instead of an accident.
+
+Third, automation owns the checks a human would forget.
+Tests, coverage, and code formatting are run by the pipeline on every pull request rather than from memory.
+
+The Release Train Engineers in each subteam are responsible for ensuring their subteam follows this plan in full.
+All members of each team are collectively responsible for integrating these standards into the code they produce.
+
+## Software Testing Plan
+
+### Approach
+
+Testing operates at four levels.
+
+Unit tests cover pure functions and helpers in isolation, with no database involvement.
+Examples include the room code entry helpers and the keyboard handling logic.
+
+Integration tests exercise each server method through the real remote procedure call against a real database instance.
+A single method test therefore proves the method's logic, its database writes, and its error responses together, rather than proving them separately against mocks that may not reflect reality.
+
+Publication tests assert the properties that control what data each client is allowed to receive.
+Three of these properties are load bearing: only the current round is published, a player's submitted answer is never published to other clients, and every publication is scoped to a single game room.
+The second of these matters most, because publishing a submitted answer would hand the correct sequence to every player who had not yet played that round.
+These properties are verified by automated tests rather than assumed.
+
+Whole-game testing exercises the complete loop, from entering a room code through gameplay and elimination to the end-of-game ranking screen.
+This is performed manually against a running deployment before each milestone, and under simulated load using purpose-built scripts that connect one hundred concurrent simulated players to a single room and play several rounds.
+
+### Developer obligations
+
+Each developer writes unit tests for the code they add, and updates existing tests when they change existing behaviour.
+
+New test files are placed alongside the existing ones and are discovered automatically by the test runner, so no manual registration step can be forgotten.
+
+Each test is named after the behaviour it verifies, so that a failure reported by the pipeline is understandable without opening the file.
+
+Team members take responsibility for the tests they write.
+A test that is incorrect, unreliable, or asserting the wrong thing is that author's responsibility to correct, whether or not the current change caused the failure.
+
+Because all tests share a single database instance, each test clears the data it touches before it runs, so that tests cannot pass or fail depending on the order in which they execute.
+
+### Continuous integration
+
+Automated tests run on every pull request targeting the integration and production branches.
+The pipeline provisions a clean database, installs the framework and dependencies from a cache, runs the full suite against the complete application, and produces a code coverage report that is retained as a build artifact.
+
+No branch may be merged while the automated tests are failing.
+
+Coverage is currently enforced at a deliberately low threshold.
+This is an honest description of its purpose: it is a smoke gate that proves the suite ran and that the application was instrumented correctly, not a quality gate that certifies the depth of coverage.
+Raising the threshold is a planned step, and it should be raised in step with closing the coverage gaps described below rather than raised on its own, since an arbitrary increase would only encourage tests written to satisfy a number.
+
+Code formatting is enforced by a single automated formatter with a shared configuration, so that formatting is never a subject of code review.
+
+### Known coverage gaps
+
+Naming the gaps is part of the plan.
+A gap that is documented can be scheduled; a gap that is implied by silence cannot be.
+
+There are currently no automated tests for authorisation, because the server does not yet verify that the connection sending an identifier is the connection that owns it.
+This is recorded in the defect register as an outstanding high severity defect, and tests will be written alongside the fix.
+
+There are no tests for concurrency or race conditions.
+The register records several read-then-write sequences that could produce inconsistent results if two clients act at exactly the same moment, and reproducing these requires a test harness capable of issuing genuinely simultaneous calls.
+
+Several room management methods, including starting a game, disconnecting, renaming a room, and reconnecting, do not yet have automated tests.
+
+There is no automated browser-driven end-to-end test.
+The full user journey is currently verified manually before each milestone.
+
+## Git Management Plan
+
+### Branch model
+
+The production branch holds runnable code and represents the most recent released version of the software.
+It should contain no defect that affects the game's core behaviour.
+
+The integration branch is the default target for all development work and is continuously deployed to a separate development environment, so that a change can be exercised in a production-shaped setting before it reaches production.
+
+Each unit of work is developed on its own branch, created from the current integration branch and named after the issue it implements, using a prefix that identifies the kind of work: feature, fix, bug, or chore.
+
+Nobody pushes directly to the production or integration branches.
+All work reaches them through a pull request.
+
+The project initially used one long-lived branch per agile subteam.
+This was replaced by one branch per issue.
+Subteam branches accumulated a week of unrelated work behind a single review, which made merge conflicts larger and reviews correspondingly shallower, since a reviewer facing several hundred lines of unrelated change tends to approve rather than examine.
+Issue-scoped branches keep each review small enough to be genuine.
+
+### Workflow
+
+Every branch is created together with a tracked issue, and is linked to that issue in the project management interface, so that the issue shows the work in progress against it.
+
+Every pull request body contains a closing reference to its issue, which causes the issue to close automatically when the pull request is merged and produces a permanent, navigable link between the requirement, the change, and the review.
+
+A pull request into the integration branch requires one approving review.
+A pull request into the production branch constitutes a production release and requires two.
+
+### Rules
+
+Commits are kept to approximately five hundred lines so that any single change can be reviewed properly and reverted cleanly if necessary.
+
+Feature branches are deleted once they have been tested, reviewed, and merged.
+
+Force pushing to any shared branch is prohibited.
+
+Commit messages follow a fixed convention that identifies the user story, the type of change, and the area affected, for example:
+
+    [user story 67] feat(leaderboard): implement initial leaderboard
+    [user story 21] fix(leaderboard): remove duplicate player entries
+
+### Code review
+
+Reviews follow a documented checklist rather than reviewer preference.
+A reviewer reads the repository's guidance document, the defect register, and, where the change affects the interface, the design system, before commenting.
+
+A review checks that the change does not silently undo a documented invariant, that any known defect is raised only if the change makes it worse, that environment-specific configuration has not been duplicated, and that the corresponding documentation was updated in the same change.
+
+Review findings are graded as must fix, should fix, or optional, and each finding points to a specific file and line.
+
+## Non-Functional Requirements
+
+The team has identified the following non-functional requirements.
+Where a requirement has been measured, the measurement is stated.
+Where it has not, it is identified as a target, so that an intention is not mistaken for a result.
+
+### Performance
+
+The system should respond to a player's action, such as tapping a coloured tile, within half a second.
+
+This requirement is currently not met under load.
+Load testing with one hundred concurrent players measured a median response time of approximately 1.1 seconds against a local deployment and approximately 4.4 seconds against the hosted development environment.
+The cause is structural and understood: the method that grades a player's submitted sequence performs between six and nine database round trips per call, and four more when the submission causes the round to advance.
+Reducing this number is the single highest value performance improvement available to the project and is scheduled accordingly.
+
+A round transition should reach every player at effectively the same moment, so that no player receives an unfair advantage in reaction time.
+
+This requirement is met.
+Across one hundred simultaneously connected clients, the spread between the first and last client to receive a new round was measured at a median of approximately twenty milliseconds.
+
+The application should load quickly when launched, and should not degrade over the course of a long session.
+Both remain targets and have not yet been formally measured.
+
+### Reliability
+
+The system should run without crashes during a game session.
+Load testing recorded zero method errors across more than five hundred gameplay submissions in each run.
+
+Delays experienced by players should be attributable to network conditions rather than to the application itself.
+The web server records both total request time and application response time separately for every request, which allows any observed delay to be attributed to the network, the web server, or the application without guesswork.
+
+Game data should remain consistent during execution.
+This requirement is partially met.
+The defect register records several read-then-write sequences which, under precisely simultaneous access, could advance a round twice, record two winners, or deduct a life based on a stale read.
+
+The application exposes separate liveness and readiness endpoints, so that the hosting platform can distinguish between a process that is running and one that is genuinely able to serve traffic.
+
+### Compatibility
+
+The game runs on both desktop and mobile devices.
+
+The interface supports screen widths from 320 pixels to 1920 pixels.
+The gameplay screen was verified across thirteen viewport sizes spanning that range.
+
+The application supports current versions of Safari, Chrome, Edge, and Firefox, and supports iOS 14 and later and Android 11 and later.
+
+Layout sizing uses viewport units that track the visible area rather than the largest possible area, so that mobile browser toolbars appearing and disappearing do not create unreachable content or dead scrolling space.
+
+### Maintainability
+
+Every module carries sufficient documentation, whether as comments or in the project documentation, to explain what it does, so that teammates and future developers extending the project can understand it without reverse engineering.
+
+The architecture is modular, with each component holding a clear and limited responsibility.
+
+New behaviour arrives together with tests.
+
+Known duplication is recorded rather than tolerated silently.
+Two instances currently exist, both documented, so that a developer who encounters one does not assume it is intentional design.
+
+### Portability
+
+Kimply is a browser-based application, so a single codebase serves devices of every architecture without platform-specific code.
+Because browsers differ in subtle ways, the game is tested across browsers to confirm that behaviour is retained rather than assumed.
+
+The production container image is built once by the automated pipeline and deployed identically to both the development and production environments, which removes an entire class of "works on my machine" failures.
+
+### Security
+
+The following controls are in place.
+
+All writes to the database pass through server-side methods.
+The framework's insecure development packages, which would allow a client to write directly to the database, are not installed, and no client-side write permissions are defined.
+
+Data published to clients is scoped to a single game room, and a player's submitted answer is never sent to other clients.
+
+The account collection is never published to any client, so password hashes and salts remain exclusively server-side.
+
+Passwords are salted and hashed before storage, are never stored in plaintext, and are subject to a minimum length requirement.
+
+Traffic is encrypted in transit using certificates managed automatically by the hosting configuration.
+
+The development and production environments share no cloud credential.
+Each environment's deployment identity is scoped to a single branch, so a change merged to the development branch cannot obtain access that reaches production.
+
+The following weaknesses are known, documented in the defect register, and scheduled.
+
+The server does not verify that the connection sending a player identifier is the connection that owns that identifier.
+A client can therefore act on another player's behalf.
+The correct fix is to bind each identifier to its connection.
+The fix is explicitly not to require player accounts.
+
+The account password hashing uses a single unstretched hash pass, compares hashes in a manner that is not constant time, and does not rate limit sign-in attempts.
+
+Server methods do not currently validate the shape of their arguments, although the validation library is available in the project.
+
+Anonymous play is a deliberate product decision, not an oversight.
+Accounts exist so that a player may have their history stored against them, and are never a prerequisite for joining a room or playing.
+A proposal to require accounts is therefore not a security fix and will not be accepted as one.
+
+### Overall Usability
+
+The design appearance and interaction style are uniform across every screen of the game.
+
+All interactive elements are visibly interactive, and navigation between screens is explicit rather than implied.
+
+The interface communicates the rules of the game without requiring separate explanation.
+
+Error messages and feedback explain the problem in the user's own terms rather than in system terms.
+
+Responsive layouts maintain usability across devices rather than merely fitting on them.
+
+### Accessibility
+
+Because the core interaction of the game is four coloured tiles, colour cannot be the sole differentiator between them.
+
+The following are implemented.
+
+Each tile renders a distinct shape in addition to its colour, so that the four tiles remain distinguishable to a player who cannot reliably distinguish the colours.
+
+Tile targets scale with the viewport and remain large enough to support users with limited motor precision.
+
+Modal dialogs are marked up with the roles and labels that assistive technology requires in order to announce them correctly.
+
+The tile palette consists of four widely separated hues at high contrast against a dark neutral background, selected to remain distinguishable under the common forms of colour vision deficiency.
+
+Typography, spacing, and labelling are consistent throughout, and the language used is simple and consistent so that players of varying reading confidence can follow the game.
+
+The following gaps are known.
+
+The tile buttons do not yet carry an accessible name, so a screen reader announces an unlabelled control.
+
+There is no reduced-motion alternative, and sequence playback is driven by flashing and motion.
+
+Both are small and contained changes, and both are scheduled.
+They are stated here rather than omitted, because an accessibility section that lists only successes is not an accessibility assessment.
+
+### Scalability
+
+The system should support at least one hundred concurrent users.
+This is met with respect to connections and data distribution: all one hundred simulated connections succeeded with no failures in every load test run.
+It is not yet met with respect to response time under that load, as described under Performance.
+
+Database performance should remain efficient as data volume grows.
+Eleven indexes are created automatically when the server starts, including compound indexes matching the query used by every data publication.
+
+Storage growth is bounded automatically.
+Room and round data expires after twenty four hours, and leaderboard history after seven days, which keeps the deployment within the storage allowance of its database tier without any manual cleanup and without deleting data from beneath a game that is still in progress.
+
+The system should be able to scale further in future.
+Because every data publication is scoped to a single game room, the volume of real-time data sent by the server grows in proportion to the size of a room rather than in proportion to the size of the whole deployment.
+This is the property that makes horizontal scaling possible later, and it is protected explicitly in code review.
+
+Load testing has so far been conducted at one hundred players over five rounds.
+Testing at higher concurrency and over a complete game is scheduled.
+
+All members of each team are responsible for integrating these non-functional requirements into the software product.
+The Release Train Engineers ensure that their corresponding team does so.
+
+## Accessibility and Usability Analysis
+
+### How Kimply applies accessibility
+
+The navigation structure is consistent, so that menus, buttons, and page layouts behave the same way on every screen and the user can transfer what they learn from one screen to the next.
+
+Text is readable and is presented at a contrast level that survives visual impairment and colour vision deficiency.
+
+Validation and error messages prevent incorrect input rather than punishing it after submission, which reduces both user frustration and invalid system state.
+
+Simple and consistent language is used throughout, so that players of varying literacy can follow the instructions and the navigation.
+
+Spacing and labelling around buttons, forms, and input fields support users with motor impairments.
+
+The game tiles carry shapes as well as colours, so that colour is never the sole carrier of meaning.
+
+### Measures taken to ensure usability
+
+The interface uses a bright tile palette against a dark neutral background, which keeps the game elements prominent and the surrounding interface quiet, improving both appearance and focus.
+
+Buttons are sized generously and scale with the viewport, so that players on mobile devices can interact accurately.
+
+Clickable cards state clearly and concisely what will happen when they are selected.
+
+Confirmation popups are used for actions that are difficult to reverse.
+These popups describe the action being confirmed, which prevents accidental interaction and teaches the user what that action does for future encounters.
+
+Text placeholders describe or exemplify the expected input rather than merely labelling the field.
+
+Immediate feedback is provided throughout the game, so that the outcome of an action is never ambiguous.
+
+Controls such as Clear and Submit remain disabled until they can validly be used, which makes an invalid submission unreachable rather than merely rejected.
+
+The experience is separated into distinct stages, joining, playing, and viewing results, so that no single screen presents the user with everything at once.
+
+The final leaderboard presents the ranking visually, distinguishing the top three players from the rest through colour and animation, so that the outcome is understood at a glance rather than by interpreting raw scores.
+
+## Design System and Style Guide
+
+The interface follows a single documented design system covering colour, typography, spacing, corner radii, elevation, motion, components, interaction patterns, and written voice.
+A player moving from the lobby to the game to the results screen encounters the same visual language, the same interaction patterns, and the same navigation structure throughout.
+
+Headings use large, bold type to establish a clear hierarchy.
+
+A minimum readable type size is maintained across devices.
+
+A single consistent colour palette is used throughout the game, with the accent colour reserved for the single most important action on any given screen.
+
+Buttons follow a standard size, spacing, and interaction style, and navigation components remain consistent across pages.
+
+Consistent spacing and alignment are applied throughout, and elements are given sufficient room to avoid overcrowding.
+
+Motion is used to convey state rather than to decorate, with defined durations and easing curves for each category of transition.
+
+### Style guide obligations
+
+Developers in each agile team follow the agreed interface standards when implementing features.
+
+Reusable components are preferred over new single-use markup.
+
+Interface changes are reviewed as part of pull request review, and are assessed against the design document rather than against individual taste.
+
+Kimply's design system is built directly on a utility-first CSS framework rather than adopting an off-the-shelf component library.
+This decision keeps the delivered bundle small, retains full control over the game's distinctive tile-based visual language, and avoids coupling the project to a third-party system whose future direction would constrain ours.
+
+## Known Gaps in This Plan
+
+The following are recorded so that the next milestone can close them deliberately rather than rediscover them.
+
+The coverage threshold is a smoke gate, which means a change can reduce meaningful coverage without failing the pipeline.
+The threshold will be raised once the untested methods identified above have tests.
+
+The automated formatting check does not yet run in the pipeline, because the existing codebase does not currently satisfy it.
+A single dedicated formatting commit is required first, after which the check can gate every pull request.
+
+There is no automated browser-driven end-to-end test, so the complete user journey is verified manually before each milestone.
+
+There are no authorisation or concurrency tests, since the corresponding defects are not yet fixed.
+These tests will be written together with the fixes rather than in advance of them.
+
+The game tiles lack an accessible name, and the application provides no reduced-motion alternative.
+
+Load testing has been performed at one hundred concurrent players over five rounds only, which meets the stated requirement at its boundary rather than with headroom.
+Testing at higher concurrency and over a full game is scheduled.


### PR DESCRIPTION
## Summary

Documentation only. No application code changes.

- Rewrote `README.md` against the Milestone 3 submission requirements.
- Added `docs/quality-assurance-plan-submission.md`, the Quality Assurance Plan: definition of QA, software testing plan, git management plan, non-functional requirements, accessibility and usability analysis, and design system and style guide.
- Listed the plan in the `AGENTS.md` documents table and added a `docs/decision-log.md` entry.

The plan describes what the repository actually does rather than what we intended. Where a non-functional requirement has been measured, the measurement is quoted from the load test runs; where it has not, it is marked as a target. The performance NFR is recorded as **not met** at 100 concurrent players, with the structural cause, and the security section states the outstanding defects rather than omitting them. It closes with a list of its own gaps so the next milestone can close them deliberately.

This is the same change as #103, which targets `dev`. This branch was cut fresh from `main` so that the diff is documentation only. `dev` and `main` are identical on all three modified files, so the two pull requests carry the same four-file diff and will not conflict with each other.

Closes #101

## Test plan

- [ ] `README.md` renders on GitHub and its setup commands match the ones in `docker-compose.yml`.
- [ ] Every document link in the QA plan and in the `AGENTS.md` table resolves.
- [ ] The `docs/decision-log.md` entry sits above the 2026-09-01 entry, newest first.